### PR TITLE
Improve pid and log files settings

### DIFF
--- a/lib/capistrano/tasks/capistrano2.rb
+++ b/lib/capistrano/tasks/capistrano2.rb
@@ -20,7 +20,7 @@ Capistrano::Configuration.instance.load do
   namespace :sidekiq do
     def for_each_process(&block)
       fetch(:sidekiq_processes).times do |idx|
-        pid_file = if idx.zero? && fetch(:sidekiq_processes).to_i <= 1
+        pid_file = if idx.zero?
           fetch(:sidekiq_pid)
         else
           fetch(:sidekiq_pid).gsub(/\.pid$/, "-#{idx}.pid")


### PR DESCRIPTION
- when processes > 1 the pid file has its increment before the extension and all pid files have their increment (not just after the first) ;
- the log file can be configured ;
- the environment is inferred.

Inspired from mperham/sidekiq#1539 by @seuros 
