### PR TITLE
More explicit start command

### DIFF
--- a/lib/capistrano/tasks/capistrano2.rb
+++ b/lib/capistrano/tasks/capistrano2.rb
@@ -55,7 +55,7 @@ Capistrano::Configuration.instance.load do
         args.push "--index #{idx}"
         args.push "--pidfile #{pid_file}"
         args.push "--environment #{fetch(:sidekiq_env)}"
-        args.push "--logfile #{fetch(:sidekiq_log)}"
+        args.push "--logfile #{fetch(:sidekiq_log)}" if fetch(:sidekiq_log)
         args.push fetch(:sidekiq_options)
 
         if defined?(JRUBY_VERSION)

--- a/lib/capistrano/tasks/sidekiq.cap
+++ b/lib/capistrano/tasks/sidekiq.cap
@@ -78,7 +78,7 @@ namespace :sidekiq do
           args.push "--index #{idx}"
           args.push "--pidfile #{pid_file}"
           args.push "--environment #{fetch(:sidekiq_env)}"
-          args.push "--logfile #{fetch(:sidekiq_log)}"
+          args.push "--logfile #{fetch(:sidekiq_log)}" if fetch(:sidekiq_log)
           args.push fetch(:sidekiq_options)
 
           if defined?(JRUBY_VERSION)


### PR DESCRIPTION
- flags use the full "double-dash" version
- sidekiq_options are empty by default
- use an array to build the list of flags
