### PR TITLE
More robust version checking

### DIFF
--- a/lib/capistrano/sidekiq.rb
+++ b/lib/capistrano/sidekiq.rb
@@ -1,4 +1,10 @@
-if Gem::Version.new(Capistrano::VERSION).release >= Gem::Version.new('3.0.0')
+version = begin
+  Capistrano::VERSION
+rescue NameError
+  Capistrano::Version
+end
+
+if Gem::Version.new(version).release >= Gem::Version.new('3.0.0')
   load File.expand_path('../tasks/sidekiq.cap', __FILE__)
 else
   require_relative 'tasks/capistrano2'


### PR DESCRIPTION
With Capistrano 2.15, there is no `Capistrano::VERSION` constant, only a `Capistrano::Version` method.
