### PR TITLE
Fix: added a missing closing quote

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ And then execute:
     # Capfile
 
     require 'capistrano/sidekiq'
-    require 'capistrano/sidekiq/monit #to require monit tasks (V0.2.0+)
+    require 'capistrano/sidekiq/monit' #to require monit tasks (V0.2.0+)
 ```
 
 


### PR DESCRIPTION
By the way, the `capistrano/sidekiq/monit` is not in the repository.
