### PR TITLE
replace deploy:restart with deploy:publishing for capistrano 3.1

### DIFF
--- a/lib/capistrano/tasks/sidekiq.cap
+++ b/lib/capistrano/tasks/sidekiq.cap
@@ -19,7 +19,7 @@ namespace :deploy do
   before :starting, :check_sidekiq_hooks do
     invoke 'sidekiq:add_default_hooks' if fetch(:sidekiq_default_hooks)
   end
-  after :restart, :restart_sidekiq do
+  after :publishing, :restart_sidekiq do
     invoke 'sidekiq:restart' if fetch(:sidekiq_default_hooks)
   end
 end


### PR DESCRIPTION
deploy:restart is removed from capistrano 3.1
