### PR TITLE
Sidekiq is properly restarted after a crash when deploying with Capsitrano2

### DIFF
--- a/lib/capistrano/tasks/capistrano2.rb
+++ b/lib/capistrano/tasks/capistrano2.rb
@@ -40,7 +40,7 @@ Capistrano::Configuration.instance.load do
     end
 
     def stop_process(pid_file, idx)
-      run "if [ -d #{current_path} ] && [ -f #{pid_file} ] && kill -0 `cat #{pid_file}`> /dev/null 2>&1; then cd #{current_path} && #{fetch(:sidekiqctl_cmd)} stop #{pid_file} #{fetch :sidekiq_timeout} ; else echo 'Sidekiq is not running'; fi"
+      run "if [ -d #{current_path} ] && [ -f #{pid_file} ] && kill -0 `cat #{pid_file}`> /dev/null 2>&1; then cd #{current_path} && #{fetch(:sidekiqctl_cmd)} stop #{pid_file} #{fetch :sidekiq_timeout} ; else echo 'Sidekiq is not running' && if [ -f #{pid_file} ] ; then rm #{pid_file} ; fi ; fi"
     end
 
     def start_process(pid_file, idx)


### PR DESCRIPTION
Currently, if sidekiq is not running but the pid file exists, then it won't be properly started when deploying with Capistrano2.

Here is why:
- The stop method does not run sidekiqctl if the process is not running
- The start method does not run sidekiqctl is a pid file already exists

The end result is sidekiq not running after a deploy. My fix is to clean up the pid file even sidekiq is not running. 
