### PR TITLE
implemented ability to split sidekiq_roles by count of sidekiq-processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ If you need change some config in redactor, you can
 ```
 
 ## Changelog
+- 0.5.3: Custom count of processes per each host
 - 0.5.0: Multiple processes @mrsimo
 - 0.3.9: Restore daemon flag from Monit template
 - 0.3.8:
@@ -120,6 +121,8 @@ If you need change some config in redactor, you can
 - [Fabien Penso] (https://github.com/penso)
 - [Alex Dunae] (https://github.com/alexdunae)
 - [andreygerasimchuk] (https://github.com/andreygerasimchuk)
+- [Saicheg] (https://github.com/Saicheg)
+- [Alex Yakubenko] (https://github.com/alexyakubenko)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ and `low`:
 set :sidekiq_options_per_process, ["--queue high", "--queue default --queue low"]
 ```
 
+## Different number of processes per host
+
+You can configure how many processes you want to run on each host next way:
+
+```ruby
+set :sidekiq_role, [:sidekiq_small, :sidekiq_big]
+set :sidekiq_small_processes, 1
+set :sidekiq_big_processes, 4
+server 'example-small.com', roles: [:sidekiq_small]
+server 'example-big.com', roles: [:sidekiq_big]
+```
+
 ## Customizing the monit sidekiq templates
 
 If you need change some config in redactor, you can

--- a/lib/capistrano/sidekiq/version.rb
+++ b/lib/capistrano/sidekiq/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Sidekiq
-    VERSION = '0.5.2'
+    VERSION = '0.5.3'
   end
 end

--- a/lib/capistrano/tasks/capistrano2.rb
+++ b/lib/capistrano/tasks/capistrano2.rb
@@ -17,6 +17,7 @@ Capistrano::Configuration.instance.load do
 
   _cset(:sidekiq_timeout) { 10 }
   _cset(:sidekiq_role) { :app }
+
   _cset(:sidekiq_processes) { 1 }
   _cset(:sidekiq_options_per_process) { nil }
 
@@ -28,9 +29,10 @@ Capistrano::Configuration.instance.load do
   end
 
   namespace :sidekiq do
-    def for_each_process(&block)
-      fetch(:sidekiq_processes).times do |idx|
-        if idx.zero? && fetch(:sidekiq_processes) <= 1
+    def for_each_process(sidekiq_role, &block)
+      sidekiq_processes = fetch(:"#{ sidekiq_role }_processes") rescue 1
+      sidekiq_processes.times do |idx|
+        if idx.zero? && sidekiq_processes <= 1
           pid_file = fetch(:sidekiq_pid)
         else
           pid_file = fetch(:sidekiq_pid).gsub(/\.pid$/, "-#{idx}.pid")
@@ -39,15 +41,30 @@ Capistrano::Configuration.instance.load do
       end
     end
 
-    def quiet_process(pid_file, idx)
-      run "if [ -d #{current_path} ] && [ -f #{pid_file} ] && kill -0 `cat #{pid_file}`> /dev/null 2>&1; then cd #{current_path} && #{fetch(:sidekiqctl_cmd)} quiet #{pid_file} ; else echo 'Sidekiq is not running'; fi"
+    def for_each_role
+      sidekiq_roles = fetch(:sidekiq_role)
+
+      sidekiq_roles = if sidekiq_roles.respond_to?(:to_ary)
+                        sidekiq_roles.to_ary
+                      else
+                        [sidekiq_roles]
+                      end
+
+      sidekiq_roles.to_ary.each do |sidekiq_role|
+        puts "executing on ##{ sidekiq_role }" if sidekiq_roles.many?
+        yield(sidekiq_role)
+      end
     end
 
-    def stop_process(pid_file, idx)
-      run "if [ -d #{current_path} ] && [ -f #{pid_file} ] && kill -0 `cat #{pid_file}`> /dev/null 2>&1; then cd #{current_path} && #{fetch(:sidekiqctl_cmd)} stop #{pid_file} #{fetch :sidekiq_timeout} ; else echo 'Sidekiq is not running' && if [ -f #{pid_file} ] ; then rm #{pid_file} ; fi ; fi"
+    def quiet_process(pid_file, idx, sidekiq_role)
+      run "if [ -d #{current_path} ] && [ -f #{pid_file} ] && kill -0 `cat #{pid_file}`> /dev/null 2>&1; then cd #{current_path} && #{fetch(:sidekiqctl_cmd)} quiet #{pid_file} ; else echo 'Sidekiq is not running'; fi", roles: sidekiq_role
     end
 
-    def start_process(pid_file, idx)
+    def stop_process(pid_file, idx, sidekiq_role)
+      run "if [ -d #{current_path} ] && [ -f #{pid_file} ] && kill -0 `cat #{pid_file}`> /dev/null 2>&1; then cd #{current_path} && #{fetch(:sidekiqctl_cmd)} stop #{pid_file} #{fetch :sidekiq_timeout} ; else echo 'Sidekiq is not running'; fi", roles: sidekiq_role
+    end
+
+    def start_process(pid_file, idx, sidekiq_role)
       args = []
       args.push "--index #{idx}"
       args.push "--pidfile #{pid_file}"
@@ -73,35 +90,43 @@ Capistrano::Configuration.instance.load do
         args.push '--daemon'
       end
 
-      run "if [ -d #{current_path} ] && [ ! -f #{pid_file} ] || ! kill -0 `cat #{pid_file}` > /dev/null 2>&1; then cd #{current_path} ; #{fetch(:sidekiq_cmd)} #{args.compact.join(' ')} ; else echo 'Sidekiq is already running'; fi", pty: false
+      run "if [ -d #{current_path} ] && [ ! -f #{pid_file} ] || ! kill -0 `cat #{pid_file}` > /dev/null 2>&1; then cd #{current_path} ; #{fetch(:sidekiq_cmd)} #{args.compact.join(' ')} ; else echo 'Sidekiq is already running'; fi", pty: false, roles: sidekiq_role
     end
 
     desc 'Quiet sidekiq (stop accepting new work)'
     task :quiet, roles: lambda { fetch(:sidekiq_role) }, on_no_matching_servers: :continue do
-      for_each_process do |pid_file, idx|
-        quiet_process(pid_file, idx)
+      for_each_role do |sidekiq_role|
+        for_each_process(sidekiq_role) do |pid_file, idx|
+          quiet_process(pid_file, idx, sidekiq_role)
+        end
       end
     end
 
     desc 'Stop sidekiq'
     task :stop, roles: lambda { fetch(:sidekiq_role) }, on_no_matching_servers: :continue do
-      for_each_process do |pid_file, idx|
-        stop_process(pid_file, idx)
+      for_each_role do |sidekiq_role|
+        for_each_process(sidekiq_role) do |pid_file, idx|
+          stop_process(pid_file, idx, sidekiq_role)
+        end
       end
     end
 
     desc 'Start sidekiq'
     task :start, roles: lambda { fetch(:sidekiq_role) }, on_no_matching_servers: :continue do
-      for_each_process do |pid_file, idx|
-        start_process(pid_file, idx)
+      for_each_role do |sidekiq_role|
+        for_each_process(sidekiq_role) do |pid_file, idx|
+          start_process(pid_file, idx, sidekiq_role)
+        end
       end
     end
 
     desc 'Rolling-restart sidekiq'
     task :rolling_restart, roles: lambda { fetch(:sidekiq_role) }, on_no_matching_servers: :continue do
-      for_each_process do |pid_file, idx|
-        stop_process(pid_file, idx)
-        start_process(pid_file, idx)
+      for_each_role do |sidekiq_role|
+        for_each_process(sidekiq_role) do |pid_file, idx|
+          stop_process(pid_file, idx, sidekiq_role)
+          start_process(pid_file, idx, sidekiq_role)
+        end
       end
     end
 

--- a/lib/capistrano/tasks/capistrano2.rb
+++ b/lib/capistrano/tasks/capistrano2.rb
@@ -51,7 +51,7 @@ Capistrano::Configuration.instance.load do
                       end
 
       sidekiq_roles.to_ary.each do |sidekiq_role|
-        puts "executing on ##{ sidekiq_role }" if sidekiq_roles.many?
+        puts "executing on ##{ sidekiq_role }" if sidekiq_roles.size > 1
         yield(sidekiq_role)
       end
     end

--- a/lib/capistrano/tasks/sidekiq.cap
+++ b/lib/capistrano/tasks/sidekiq.cap
@@ -40,12 +40,17 @@ namespace :sidekiq do
 
   def processes_pids
     pids = []
-    fetch(:sidekiq_processes).times do |idx|
-      pids.push (idx.zero? && fetch(:sidekiq_processes) <= 1) ?
-                    fetch(:sidekiq_pid) :
-                    fetch(:sidekiq_pid).gsub(/\.pid$/, "-#{idx}.pid")
-
+    sidekiq_roles = Array(fetch(:sidekiq_role))
+    sidekiq_roles.each do |role|
+      next unless host.roles.include?(role)
+      processes = fetch(:"#{ role }_processes") || fetch(:sidekiq_processes)
+      processes.times do |idx|
+        pids.push (idx.zero? && processes <= 1) ?
+                      fetch(:sidekiq_pid) :
+                      fetch(:sidekiq_pid).gsub(/\.pid$/, "-#{idx}.pid")
+      end
     end
+
     pids
   end
 


### PR DESCRIPTION
Now we can customize how many processes capistrano has to run on each server.

set :sidekiq_role, [:sidekiq, :sidekiq_small, :sidekiq_big]

set :sidekiq_small_processes, 2
set :sidekiq_big_processes, 4

role :sidekiq, 'sidekiq.example.com'
role :sidekiq_small, 'sidekiq_small.example.com'
role :sidekiq_big, 'sidekiq_big.example.com'

It was very helpfull for me because we use different AWS-S3 instancess for sidekiq. I hope it will be helpfull for other developers.