### PR TITLE
use release_path instead of current_path

### DIFF
--- a/lib/capistrano/tasks/sidekiq.cap
+++ b/lib/capistrano/tasks/sidekiq.cap
@@ -29,7 +29,7 @@ namespace :sidekiq do
     pids = processes_pids
     pids.reverse! if reverse
     pids.each_with_index do |pid_file, idx|
-      within current_path do
+      within release_path do
         yield(pid_file, idx)
       end
     end
@@ -119,7 +119,7 @@ namespace :sidekiq do
   desc 'Quiet sidekiq (stop processing new tasks)'
   task :quiet do
     on roles fetch(:sidekiq_role) do
-      if test("[ -d #{current_path} ]") # fixes #11
+      if test("[ -d #{release_path} ]") # fixes #11
         for_each_process(true) do |pid_file, idx|
           if pid_process_exists?(pid_file)
             quiet_sidekiq(pid_file)
@@ -132,7 +132,7 @@ namespace :sidekiq do
   desc 'Stop sidekiq'
   task :stop do
     on roles fetch(:sidekiq_role) do
-      if test("[ -d #{current_path} ]")
+      if test("[ -d #{release_path} ]")
         for_each_process(true) do |pid_file, idx|
           if pid_process_exists?(pid_file)
             stop_sidekiq(pid_file)


### PR DESCRIPTION
We define ruby version in Gemfile, also use rvm on production, and recently we upgrade ruby from 2.1.2 to 2.1.3

When deploying with capistrano, it runs `sidekiq:stop` with old `current_path`, Gemfile said 2.1.2 but rvm said 2.1.3, it's fixed by replacing `current_path` with `release_path`
