### PR TITLE
Test is Sidekiq actually running when starting with Capistrano 2

### DIFF
--- a/lib/capistrano/tasks/capistrano2.rb
+++ b/lib/capistrano/tasks/capistrano2.rb
@@ -59,7 +59,7 @@ Capistrano::Configuration.instance.load do
         args.push '--daemon'
       end
 
-      run "if [ -d #{current_path} ] && [ ! -f #{pid_file} ]; then cd #{current_path} ; #{fetch(:sidekiq_cmd)} #{args.compact.join(' ')} ; else echo 'Sidekiq is already running'; fi", pty: false
+      run "if [ -d #{current_path} ] && [ ! -f #{pid_file} ] || ! kill -0 `cat #{pid_file}` > /dev/null 2>&1; then cd #{current_path} ; #{fetch(:sidekiq_cmd)} #{args.compact.join(' ')} ; else echo 'Sidekiq is already running'; fi", pty: false
     end
 
     desc 'Quiet sidekiq (stop accepting new work)'


### PR DESCRIPTION
Testing PID file presence is not enough as sometimes Sidekiq may crash leaving PID file present with not actual PID in it. In that case `cap sidekiq:start` won't start it. This is a fix for such a situation.
