### PR TITLE
Update defaults for Cap 2

### DIFF
--- a/lib/capistrano/tasks/capistrano2.rb
+++ b/lib/capistrano/tasks/capistrano2.rb
@@ -7,6 +7,7 @@ Capistrano::Configuration.instance.load do
   _cset(:sidekiq_tag) { nil }
   _cset(:sidekiq_log) { File.join(shared_path, 'log', 'sidekiq.log') }
 
+  _cset(:sidekiq_config) { "#{current_path}/config/sidekiq.yml" }
   _cset(:sidekiq_options) { nil }
 
   _cset(:sidekiq_cmd) { "#{fetch(:bundle_cmd, 'bundle')} exec sidekiq" }
@@ -50,6 +51,7 @@ Capistrano::Configuration.instance.load do
       args.push "--environment #{fetch(:sidekiq_env)}"
       args.push "--tag #{fetch(:sidekiq_tag)}" if fetch(:sidekiq_tag)
       args.push "--logfile #{fetch(:sidekiq_log)}" if fetch(:sidekiq_log)
+      args.push "--config #{fetch(:sidekiq_config)}" if fetch(:sidekiq_config)
       args.push fetch(:sidekiq_options)
 
       if defined?(JRUBY_VERSION)


### PR DESCRIPTION
When using Capistrano 2, sidekiq.yml is not recognized by default. I've tried using this gem on two different servers and Sidekiq didn't pick up sidekiq.yml on either. 

In addition, the Capistrano 2 tasks didn't have the sidekiq_config option that the Capistrano 3 tasks have.

This is an update to correct this.
