### PR TITLE
Add queues setup in capistrano2 task

### DIFF
--- a/lib/capistrano/tasks/capistrano2.rb
+++ b/lib/capistrano/tasks/capistrano2.rb
@@ -50,6 +50,9 @@ Capistrano::Configuration.instance.load do
       args.push "--environment #{fetch(:sidekiq_env)}"
       args.push "--tag #{fetch(:sidekiq_tag)}" if fetch(:sidekiq_tag)
       args.push "--logfile #{fetch(:sidekiq_log)}" if fetch(:sidekiq_log)
+      fetch(:sidekiq_queue).each do |queue|
+        args.push "--queue #{queue}"
+      end if fetch(:sidekiq_queue)
       args.push fetch(:sidekiq_options)
 
       if defined?(JRUBY_VERSION)


### PR DESCRIPTION
Right now this option exists and being used in monit configuration (https://github.com/seuros/capistrano-sidekiq/blob/master/lib/capistrano/tasks/monit.cap#L96 ), but as I see - no such possibility in capistrano2 task.
