### PR TITLE
Set default option for sidekiq queue in capistrano 2 script

### DIFF
--- a/lib/capistrano/tasks/capistrano2.rb
+++ b/lib/capistrano/tasks/capistrano2.rb
@@ -8,6 +8,7 @@ Capistrano::Configuration.instance.load do
   _cset(:sidekiq_log) { File.join(shared_path, 'log', 'sidekiq.log') }
 
   _cset(:sidekiq_options) { nil }
+  _cset(:sidekiq_queue) { nil }
 
   _cset(:sidekiq_cmd) { "#{fetch(:bundle_cmd, 'bundle')} exec sidekiq" }
   _cset(:sidekiqctl_cmd) { "#{fetch(:bundle_cmd, 'bundle')} exec sidekiqctl" }


### PR DESCRIPTION
Hello

Unfortunately, there was an error in my PR https://github.com/seuros/capistrano-sidekiq/pull/57 - I haven't specified default option to sidekiq_queue, which caused failures when this variable is not set.

Sorry for that.
