### PR TITLE
Try execute on the monit.conf mv command

### DIFF
--- a/lib/capistrano/tasks/monit.cap
+++ b/lib/capistrano/tasks/monit.cap
@@ -27,7 +27,16 @@ namespace :sidekiq do
       on roles(fetch(:sidekiq_role)) do |role|
         @role = role
         template_sidekiq 'sidekiq_monit', "#{fetch(:tmp_dir)}/monit.conf", @role
-        sudo "mv #{fetch(:tmp_dir)}/monit.conf #{fetch(:sidekiq_monit_conf_dir)}/#{sidekiq_service_name}.conf"
+
+        mv_command = "mv #{fetch(:tmp_dir)}/monit.conf #{fetch(:sidekiq_monit_conf_dir)}/#{sidekiq_service_name}.conf"
+
+        # Try execute in case the deploy user doesn't have sudo to mv
+        begin
+          execute mv_command
+        rescue
+          sudo mv_command
+        end
+
         sudo "#{fetch(:monit_bin)} reload"
       end
     end


### PR DESCRIPTION
PR to try `execute` on the monit.conf `mv` command in case the deploy user doesn't have sudo for `mv`. In our deploy environment, we don't want the deploy user to have general sudo access, only to the commands that are essential (e.g. `monit`). So this plugin works fine except the deploy user needs sudo to `mv` to move the file out of `/tmp` into the monit config dir.