### PR TITLE
Options per process

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Configurable options, shown here with defaults:
     :sidekiq_timeout => 10
     :sidekiq_role => :app
     :sidekiq_processes => 1
+    :sidekiq_options_per_process => nil
     :sidekiq_concurrency => nil
     :sidekiq_monit_templates_path => 'config/deploy/templates'
     :sidekiq_cmd => "#{fetch(:bundle_cmd, "bundle")} exec sidekiq" # Only for capistrano2.5
@@ -53,6 +54,19 @@ Configurable options, shown here with defaults:
 There is a known bug that prevents sidekiq from starting when pty is true
 ```ruby
 set :pty,  false
+```
+
+## Multiple processes
+
+You can configure sidekiq to start with multiple processes. Just set the proper amount in `sidekiq_processes`.
+
+You can also customize the configuration for every process. If you want to do that, just set
+`sidekiq_options_per_process` with an array of the configuration options that you want in string format.
+This example should boot the first process with the queue `high` and the second one with the queues `default`
+and `low`:
+
+```ruby
+set :sidekiq_options_per_process, ["--queue high", "--queue default --queue low"]
 ```
 
 ## Customizing the monit sidekiq templates

--- a/lib/capistrano/tasks/capistrano2.rb
+++ b/lib/capistrano/tasks/capistrano2.rb
@@ -17,6 +17,7 @@ Capistrano::Configuration.instance.load do
   _cset(:sidekiq_timeout) { 10 }
   _cset(:sidekiq_role) { :app }
   _cset(:sidekiq_processes) { 1 }
+  _cset(:sidekiq_options_per_process) { nil }
 
   if fetch(:sidekiq_default_hooks)
     before 'deploy:update_code', 'sidekiq:quiet'
@@ -56,6 +57,11 @@ Capistrano::Configuration.instance.load do
       fetch(:sidekiq_queue).each do |queue|
         args.push "--queue #{queue}"
       end if fetch(:sidekiq_queue)
+
+      if process_options = fetch(:sidekiq_options_per_process)
+        args.push process_options[idx]
+      end
+
       args.push fetch(:sidekiq_options)
 
       if defined?(JRUBY_VERSION)

--- a/lib/capistrano/tasks/sidekiq.cap
+++ b/lib/capistrano/tasks/sidekiq.cap
@@ -8,6 +8,7 @@ namespace :load do
     set :sidekiq_timeout, -> { 10 }
     set :sidekiq_role, -> { :app }
     set :sidekiq_processes, -> { 1 }
+    set :sidekiq_options_per_process, -> { nil }
     # Rbenv and RVM integration
     set :rbenv_map_bins, fetch(:rbenv_map_bins).to_a.concat(%w(sidekiq sidekiqctl))
     set :rvm_map_bins, fetch(:rvm_map_bins).to_a.concat(%w(sidekiq sidekiqctl))
@@ -94,6 +95,9 @@ namespace :sidekiq do
     end
     args.push "--config #{fetch(:sidekiq_config)}" if fetch(:sidekiq_config)
     args.push "--concurrency #{fetch(:sidekiq_concurrency)}" if fetch(:sidekiq_concurrency)
+    if process_options = fetch(:sidekiq_options_per_process)
+      args.push process_options[idx]
+    end
     # use sidekiq_options for special options
     args.push fetch(:sidekiq_options) if fetch(:sidekiq_options)
 


### PR DESCRIPTION
Hi there,

We are interested in booting different processes for different queues, because some jobs are really slow and might saturate our workers. I've been thinking about it and I think this is a very simple way to just let people customize every process. This could be improved in many ways, like different options per server/role and all that, but I think it's simple enough as it is, and would be pretty useful to many people.

I hope you consider merging this. In any case, thanks a lot for this project, it's worked really great for us!

Cheers!