### PR TITLE
Support sidekiq_concurrency option for capistrano 2

### DIFF
--- a/lib/capistrano/tasks/capistrano2.rb
+++ b/lib/capistrano/tasks/capistrano2.rb
@@ -54,6 +54,7 @@ Capistrano::Configuration.instance.load do
       args.push "--tag #{fetch(:sidekiq_tag)}" if fetch(:sidekiq_tag)
       args.push "--logfile #{fetch(:sidekiq_log)}" if fetch(:sidekiq_log)
       args.push "--config #{fetch(:sidekiq_config)}" if fetch(:sidekiq_config)
+      args.push "--concurrency #{fetch(:sidekiq_concurrency)}" if fetch(:sidekiq_concurrency)
       fetch(:sidekiq_queue).each do |queue|
         args.push "--queue #{queue}"
       end if fetch(:sidekiq_queue)


### PR DESCRIPTION
Copied from [the cap3 version](https://github.com/seuros/capistrano-sidekiq/blob/master/lib/capistrano/tasks/sidekiq.cap#L97).