### PR TITLE
Set sidekiq_concurrency default value for cap 2 (improves pr #72).

### DIFF
--- a/lib/capistrano/tasks/capistrano2.rb
+++ b/lib/capistrano/tasks/capistrano2.rb
@@ -10,6 +10,7 @@ Capistrano::Configuration.instance.load do
   _cset(:sidekiq_config) { "#{current_path}/config/sidekiq.yml" }
   _cset(:sidekiq_options) { nil }
   _cset(:sidekiq_queue) { nil }
+  _cset(:sidekiq_concurrency) { nil }
 
   _cset(:sidekiq_cmd) { "#{fetch(:bundle_cmd, 'bundle')} exec sidekiq" }
   _cset(:sidekiqctl_cmd) { "#{fetch(:bundle_cmd, 'bundle')} exec sidekiqctl" }


### PR DESCRIPTION
A ``fetch(:sidekiq_concurrency)``` call throws an exception if no sidekiq_concurrency has been set. This pull-request simply adds a default nil value.