### PR TITLE
Add nohup when executing start_sidekiq command, for a problem with pty.

### DIFF
--- a/lib/capistrano/tasks/sidekiq.cap
+++ b/lib/capistrano/tasks/sidekiq.cap
@@ -116,7 +116,7 @@ namespace :sidekiq do
     if fetch(:start_sidekiq_in_background, fetch(:sidekiq_run_in_background))
       background :bundle, :exec, :sidekiq, args.compact.join(' ')
     else
-      execute :bundle, :exec, :sidekiq, args.compact.join(' ')
+      execute :nohup, :bundle, :exec, :sidekiq, args.compact.join(' ')
     end
   end
 


### PR DESCRIPTION
This Pull Request will fix pty problem.

I tried to apply this branch, and starting sidekiq was success with

```ruby
set :pty, true
```

Please consider this.