### PR TITLE
move sidekiq_options to the end of the args array

### DIFF
--- a/lib/capistrano/tasks/sidekiq.cap
+++ b/lib/capistrano/tasks/sidekiq.cap
@@ -103,15 +103,16 @@ namespace :sidekiq do
     if process_options = fetch(:sidekiq_options_per_process)
       args.push process_options[idx]
     end
-    # use sidekiq_options for special options
-    args.push fetch(:sidekiq_options) if fetch(:sidekiq_options)
-
+    
     if defined?(JRUBY_VERSION)
       args.push '>/dev/null 2>&1 &'
       warn 'Since JRuby doesn\'t support Process.daemon, Sidekiq will not be running as a daemon.'
     else
       args.push '--daemon'
     end
+
+    # use sidekiq_options for special options
+    args.push fetch(:sidekiq_options) if fetch(:sidekiq_options)
 
     if fetch(:start_sidekiq_in_background, fetch(:sidekiq_run_in_background))
       background :bundle, :exec, :sidekiq, args.compact.join(' ')


### PR DESCRIPTION
This allows setting environment variables as well. For example if we have SIDEKIQ=true to let the app know that it is being run by sidekiq so it can use eager loading and so forth.