### PR TITLE
Add support for different number of processes per host on monit.cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ set :sidekiq_monit_use_sudo, false
 ```
 
 ## Changelog
+- 0.5.4: Add support for custom count of processes per host in monit task @okoriko
 - 0.5.3: Custom count of processes per each host
 - 0.5.0: Multiple processes @mrsimo
 - 0.3.9: Restore daemon flag from Monit template
@@ -131,6 +132,7 @@ set :sidekiq_monit_use_sudo, false
 - [Saicheg] (https://github.com/Saicheg)
 - [Alex Yakubenko] (https://github.com/alexyakubenko)
 - [Robert Strobl] (https://github.com/rstrobl)
+- [Eurico Doirado] (https://github.com/okoriko)
 
 ## Contributing
 

--- a/lib/capistrano/sidekiq/version.rb
+++ b/lib/capistrano/sidekiq/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Sidekiq
-    VERSION = '0.5.3'
+    VERSION = '0.5.4'
   end
 end

--- a/lib/capistrano/tasks/monit.cap
+++ b/lib/capistrano/tasks/monit.cap
@@ -38,13 +38,15 @@ namespace :sidekiq do
 
     desc 'Monitor Sidekiq monit-service'
     task :monitor do
-      on roles(fetch(:sidekiq_role)) do
-        fetch(:sidekiq_processes).times do |idx|
-          begin
-            sudo_if_needed "#{fetch(:monit_bin)} monitor #{sidekiq_service_name(idx)}"
-          rescue
-            invoke 'sidekiq:monit:config'
-            sudo_if_needed "#{fetch(:monit_bin)} monitor #{sidekiq_service_name(idx)}"
+      Array(fetch(:sidekiq_role)).each do |role|
+        on roles(role) do
+          sidekiq_processes(role).times do |idx|
+            begin
+              sudo_if_needed "#{fetch(:monit_bin)} monitor #{sidekiq_service_name(idx)}"
+            rescue
+              invoke 'sidekiq:monit:config'
+              sudo_if_needed "#{fetch(:monit_bin)} monitor #{sidekiq_service_name(idx)}"
+            end
           end
         end
       end
@@ -52,12 +54,14 @@ namespace :sidekiq do
 
     desc 'Unmonitor Sidekiq monit-service'
     task :unmonitor do
-      on roles(fetch(:sidekiq_role)) do
-        fetch(:sidekiq_processes).times do |idx|
-          begin
-            sudo_if_needed "#{fetch(:monit_bin)} unmonitor #{sidekiq_service_name(idx)}"
-          rescue
-            # no worries here
+      Array(fetch(:sidekiq_role)).each do |role|
+        on roles(role) do
+          sidekiq_processes(role).times do |idx|
+            begin
+              sudo_if_needed "#{fetch(:monit_bin)} unmonitor #{sidekiq_service_name(idx)}"
+            rescue
+              # no worries here
+            end
           end
         end
       end
@@ -65,27 +69,33 @@ namespace :sidekiq do
 
     desc 'Start Sidekiq monit-service'
     task :start do
-      on roles(fetch(:sidekiq_role)) do
-        fetch(:sidekiq_processes).times do |idx|
-          sudo_if_needed "#{fetch(:monit_bin)} start #{sidekiq_service_name(idx)}"
+      Array(fetch(:sidekiq_role)).each do |role|
+        on roles(role) do
+          sidekiq_processes(role).times do |idx|
+            sudo_if_needed "#{fetch(:monit_bin)} start #{sidekiq_service_name(idx)}"
+          end
         end
       end
     end
 
     desc 'Stop Sidekiq monit-service'
     task :stop do
-      on roles(fetch(:sidekiq_role)) do
-        fetch(:sidekiq_processes).times do |idx|
-          sudo_if_needed "#{fetch(:monit_bin)} stop #{sidekiq_service_name(idx)}"
+      Array(fetch(:sidekiq_role)).each do |role|
+        on roles(role) do
+          sidekiq_processes(role).times do |idx|
+            sudo_if_needed "#{fetch(:monit_bin)} stop #{sidekiq_service_name(idx)}"
+          end
         end
       end
     end
 
     desc 'Restart Sidekiq monit-service'
     task :restart do
-      on roles(fetch(:sidekiq_role)) do
-        fetch(:sidekiq_processes).times do |idx|
-          sudo_if_needed"#{fetch(:monit_bin)} restart #{sidekiq_service_name(idx)}"
+      Array(fetch(:sidekiq_role)).each do |role|
+        on roles(role) do
+          sidekiq_processes(role).times do |idx|
+            sudo_if_needed"#{fetch(:monit_bin)} restart #{sidekiq_service_name(idx)}"
+          end
         end
       end
     end
@@ -124,6 +134,10 @@ namespace :sidekiq do
 
     def use_sudo?
       fetch(:sidekiq_monit_use_sudo)
+    end
+
+    def sidekiq_processes(role)
+      fetch(:"#{ role }_processes") || fetch(:sidekiq_processes)
     end
 
   end


### PR DESCRIPTION
Support for different number of processes per host has already been merged on master, but was missing from monit.cap.
This PR should fix that issue.