### PR TITLE
Use SSHKit command_map

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ set :sidekiq_monit_use_sudo, false
 - [Alex Yakubenko] (https://github.com/alexyakubenko)
 - [Robert Strobl] (https://github.com/rstrobl)
 - [Eurico Doirado] (https://github.com/okoriko)
+- [Huang Bin](https://github.com/hbin)
 
 ## Contributing
 

--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -12,6 +12,8 @@ namespace :load do
     # Rbenv and RVM integration
     set :rbenv_map_bins, fetch(:rbenv_map_bins).to_a.concat(%w(sidekiq sidekiqctl))
     set :rvm_map_bins, fetch(:rvm_map_bins).to_a.concat(%w(sidekiq sidekiqctl))
+    # Bundler integration
+    set :bundle_bins, fetch(:bundle_bins).to_a.concat(%w(sidekiq sidekiqctl))
   end
 end
 
@@ -64,10 +66,10 @@ namespace :sidekiq do
       if fetch(:sidekiq_use_signals)
         background "kill -TERM `cat #{pid_file}`"
       else
-        background :bundle, :exec, :sidekiqctl, 'stop', "#{pid_file}", fetch(:sidekiq_timeout)
+        background :sidekiqctl, 'stop', "#{pid_file}", fetch(:sidekiq_timeout)
       end
     else
-      execute :bundle, :exec, :sidekiqctl, 'stop', "#{pid_file}", fetch(:sidekiq_timeout)
+      execute :sidekiqctl, 'stop', "#{pid_file}", fetch(:sidekiq_timeout)
     end
   end
 
@@ -76,7 +78,7 @@ namespace :sidekiq do
       background "kill -USR1 `cat #{pid_file}`"
     else
       begin
-        execute :bundle, :exec, :sidekiqctl, 'quiet', "#{pid_file}"
+        execute :sidekiqctl, 'quiet', "#{pid_file}"
       rescue SSHKit::Command::Failed
         # If gems are not installed eq(first deploy) and sidekiq_default_hooks as active
         warn 'sidekiqctl not found (ignore if this is the first deploy)'
@@ -111,9 +113,9 @@ namespace :sidekiq do
     end
 
     if fetch(:start_sidekiq_in_background, fetch(:sidekiq_run_in_background))
-      background :bundle, :exec, :sidekiq, args.compact.join(' ')
+      background :sidekiq, args.compact.join(' ')
     else
-      execute :bundle, :exec, :sidekiq, args.compact.join(' ')
+      execute :sidekiq, args.compact.join(' ')
     end
   end
 

--- a/lib/generators/capistrano/sidekiq/monit/templates/sidekiq_monit.conf.erb
+++ b/lib/generators/capistrano/sidekiq/monit/templates/sidekiq_monit.conf.erb
@@ -2,9 +2,9 @@
 <% processes_pids.each_with_index do |pid_file, idx| %>
 check process <%= sidekiq_service_name(idx) %>
   with pidfile "<%= pid_file %>"
-  start program = "/bin/su - <%= @role.user %> -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:bundle] %> exec sidekiq  <%= sidekiq_config %> --index <%= idx %> --pidfile <%= pid_file %> --environment <%= fetch(:sidekiq_env) %> <%= sidekiq_concurrency %> <%= sidekiq_logfile %> <%= sidekiq_queues %> -d'" with timeout 30 seconds
+  start program = "/bin/su - <%= @role.user %> -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:sidekiq] %> <%= sidekiq_config %> --index <%= idx %> --pidfile <%= pid_file %> --environment <%= fetch(:sidekiq_env) %> <%= sidekiq_concurrency %> <%= sidekiq_logfile %> <%= sidekiq_queues %> -d'" with timeout 30 seconds
 
-  stop program = "/bin/su - <%= @role.user %> -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:bundle] %> exec sidekiqctl stop <%= pid_file %>'" with timeout <%= fetch(:sidekiq_timeout).to_i + 10  %> seconds
+  stop program = "/bin/su - <%= @role.user %> -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:sidekiqctl] %> stop <%= pid_file %>'" with timeout <%= fetch(:sidekiq_timeout).to_i + 10  %> seconds
   group <%= fetch(:sidekiq_monit_group, fetch(:application)) %>-sidekiq
 
 <% end %>


### PR DESCRIPTION
Same as https://github.com/seuros/capistrano-puma/pull/128

We don't need to explicitly specify the `bundle exec` statement(actually, we shouldn't).

The best practice is [add the binaries to the bundle_bins array](https://github.com/capistrano/bundler/blob/master/lib%2Fcapistrano%2Ftasks%2Fbundler.cap#L44-L47).

With following the best practice, the user can easily to custom the execution command, for example, I am  going to use the [dotenv](https://github.com/bkeepers/dotenv) executable to launch the sidekiq. I can add an additive task like this:
```
namespace :bundler do
  task :map_bins do
    fetch(:bundle_bins).each do |command|
      SSHKit.config.command_map.prefix[command.to_sym].push('dotenv')
    end
  end
end
```