### PR TITLE
Restart sidekiq after a rollback

### DIFF
--- a/lib/capistrano/tasks/capistrano2.rb
+++ b/lib/capistrano/tasks/capistrano2.rb
@@ -26,6 +26,7 @@ Capistrano::Configuration.instance.load do
     after 'deploy:stop', 'sidekiq:stop'
     after 'deploy:start', 'sidekiq:start'
     before 'deploy:restart', 'sidekiq:restart'
+    after 'deploy:rollback', 'sidekiq:restart'
   end
 
   namespace :sidekiq do


### PR DESCRIPTION
We just had a problem with our deploys and they rollbacked automatically. Sidekiq was silenced before it failed, and it wasn't restarted after the rollback, so it stopped processing jobs for a while.

It seems like the sensible thing to do is to restart the sidekiq processe (since I don't see how to unsilence them).

I'm not sure if [capistrano3's hooks](https://github.com/seuros/capistrano-sidekiq/blob/0d85831168ec54861ad704cc47d943a8b1cad6f6/lib/capistrano/tasks/sidekiq.rake#L123-L126) take care of this situation already, I'm not familiar with it.

