### PR TITLE
Add sidekiq_stop_tries to try stopping sidekiq completely

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Configurable options, shown here with defaults:
     :sidekiq_config => nil
     :sidekiq_queue => nil
     :sidekiq_timeout => 10
+    :sidekiq_stop_tries => 1
     :sidekiq_role => :app
     :sidekiq_processes => 1
     :sidekiq_options_per_process => nil


### PR DESCRIPTION
I had found that sidekiq didn't start during deployment.
If sidekiq has many enqueued jobs, it takes long time to stop sidekiq.
In this situation, sidekiq doesn't start again.
So I've added sidekiq_stop_tries option.
