### PR TITLE
Capistrano 2 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Configurable options, shown here with defaults:
     :sidekiq_monit_use_sudo => true
     :sidekiq_cmd => "#{fetch(:bundle_cmd, "bundle")} exec sidekiq" # Only for capistrano2.5
     :sidekiqctl_cmd => "#{fetch(:bundle_cmd, "bundle")} exec sidekiqctl" # Only for capistrano2.5
+    :sidekiq_user => nil #user to run sidekiq as
 ```
 
 There is a known bug that prevents sidekiq from starting when pty is true on Capistrano 3.

--- a/lib/capistrano/tasks/capistrano2.rb
+++ b/lib/capistrano/tasks/capistrano2.rb
@@ -59,8 +59,12 @@ Capistrano::Configuration.instance.load do
     end
 
     def run_as(cmd)
+      opts = {
+        roles: sidekiq_role
+      }
       su_user = fetch(:sidekiq_user)
-      run cmd, roles: sidekiq_role, shell: "su - #{su_user}"
+      opts[:shell] = "su - #{su_user}" if su_user
+      run cmd, opts
     end
 
     def quiet_process(pid_file, idx, sidekiq_role)

--- a/lib/capistrano/tasks/capistrano2.rb
+++ b/lib/capistrano/tasks/capistrano2.rb
@@ -95,7 +95,7 @@ Capistrano::Configuration.instance.load do
         args.push '--daemon'
       end
 
-      run_as "if [ -d #{current_path} ] && [ ! -f #{pid_file} ] || ! kill -0 `cat #{pid_file}` > /dev/null 2>&1; then cd #{current_path} ; #{fetch(:sidekiq_cmd)} #{args.compact.join(' ')} ; else echo 'Sidekiq is already running'; fi", pty: false
+      run_as "if [ -d #{current_path} ] && [ ! -f #{pid_file} ] || ! kill -0 `cat #{pid_file}` > /dev/null 2>&1; then cd #{current_path} ; #{fetch(:sidekiq_cmd)} #{args.compact.join(' ')} ; else echo 'Sidekiq is already running'; fi"
     end
 
     desc 'Quiet sidekiq (stop accepting new work)'

--- a/lib/capistrano/tasks/capistrano2.rb
+++ b/lib/capistrano/tasks/capistrano2.rb
@@ -21,6 +21,8 @@ Capistrano::Configuration.instance.load do
   _cset(:sidekiq_processes) { 1 }
   _cset(:sidekiq_options_per_process) { nil }
 
+  _cset(:sidekiq_user) { nil }
+
   if fetch(:sidekiq_default_hooks)
     before 'deploy:update_code', 'sidekiq:quiet'
     after 'deploy:stop', 'sidekiq:stop'

--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -9,6 +9,7 @@ namespace :load do
     set :sidekiq_role, -> { :app }
     set :sidekiq_processes, -> { 1 }
     set :sidekiq_options_per_process, -> { nil }
+    set :sidekiq_user, -> { nil }
     # Rbenv and RVM integration
     set :rbenv_map_bins, fetch(:rbenv_map_bins).to_a.concat(%w(sidekiq sidekiqctl))
     set :rvm_map_bins, fetch(:rvm_map_bins).to_a.concat(%w(sidekiq sidekiqctl))

--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -216,7 +216,7 @@ namespace :sidekiq do
   end
 
   def switch_user(&block)
-    su_user = fetch(:puma_user)
+    su_user = fetch(:sidekiq_user)
     if su_user
       as su_user do
         yield


### PR DESCRIPTION
Hello!

I've got a few minor fixes for capistrano 2 that we encountered when trying to use this in our setup:

* There was an extraneous `pty: false` at the end of a `run_as` command
* `sidekiq_user` was not optional like it was in the capistrano 3 task
* The capistrano 3 task was using `puma_user` and not `sidekiq_user`
* Made `sidekiq_user` `nil` by default and added some documentation

Thanks!