### PR TITLE
Respect both local and global puma_user setting everywhere

### DIFF
--- a/lib/capistrano/tasks/monit.rake
+++ b/lib/capistrano/tasks/monit.rake
@@ -119,6 +119,12 @@ namespace :sidekiq do
       end
     end
 
+    def sidekiq_require
+      if fetch(:sidekiq_require)
+        "--require #{fetch(:sidekiq_require)}"
+      end
+    end
+
     def sidekiq_options_per_process
       fetch(:sidekiq_options_per_process) || []
     end

--- a/lib/generators/capistrano/sidekiq/monit/templates/sidekiq_monit.conf.erb
+++ b/lib/generators/capistrano/sidekiq/monit/templates/sidekiq_monit.conf.erb
@@ -2,7 +2,7 @@
 <% processes_pids.each_with_index do |pid_file, idx| %>
 check process <%= sidekiq_service_name(idx) %>
   with pidfile "<%= pid_file %>"
-  start program = "/bin/su - <%= sidekiq_user(@role) %> -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:sidekiq] %> <%= sidekiq_config %> --index <%= idx %> --pidfile <%= pid_file %> --environment <%= fetch(:sidekiq_env) %> <%= sidekiq_concurrency %> <%= sidekiq_logfile %> <%= sidekiq_queues %> <%= sidekiq_options_per_process[idx] %> -d'" with timeout 30 seconds
+  start program = "/bin/su - <%= sidekiq_user(@role) %> -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:sidekiq] %> <%= sidekiq_config %> --index <%= idx %> --pidfile <%= pid_file %> --environment <%= fetch(:sidekiq_env) %> <%= sidekiq_concurrency %> <%= sidekiq_logfile %> <%= sidekiq_require %> <%= sidekiq_queues %> <%= sidekiq_options_per_process[idx] %> -d'" with timeout 30 seconds
 
   stop program = "/bin/su - <%= sidekiq_user(@role) %> -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:sidekiqctl] %> stop <%= pid_file %>'" with timeout <%= fetch(:sidekiq_timeout).to_i + 10  %> seconds
   group <%= fetch(:sidekiq_monit_group, fetch(:application)) %>-sidekiq

--- a/lib/generators/capistrano/sidekiq/monit/templates/sidekiq_monit.conf.erb
+++ b/lib/generators/capistrano/sidekiq/monit/templates/sidekiq_monit.conf.erb
@@ -2,9 +2,9 @@
 <% processes_pids.each_with_index do |pid_file, idx| %>
 check process <%= sidekiq_service_name(idx) %>
   with pidfile "<%= pid_file %>"
-  start program = "/bin/su - <%= @role.user %> -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:sidekiq] %> <%= sidekiq_config %> --index <%= idx %> --pidfile <%= pid_file %> --environment <%= fetch(:sidekiq_env) %> <%= sidekiq_concurrency %> <%= sidekiq_logfile %> <%= sidekiq_queues %> <%= sidekiq_options_per_process[idx] %> -d'" with timeout 30 seconds
+  start program = "/bin/su - <%= sidekiq_user(@role) %> -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:sidekiq] %> <%= sidekiq_config %> --index <%= idx %> --pidfile <%= pid_file %> --environment <%= fetch(:sidekiq_env) %> <%= sidekiq_concurrency %> <%= sidekiq_logfile %> <%= sidekiq_queues %> <%= sidekiq_options_per_process[idx] %> -d'" with timeout 30 seconds
 
-  stop program = "/bin/su - <%= @role.user %> -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:sidekiqctl] %> stop <%= pid_file %>'" with timeout <%= fetch(:sidekiq_timeout).to_i + 10  %> seconds
+  stop program = "/bin/su - <%= sidekiq_user(@role) %> -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:sidekiqctl] %> stop <%= pid_file %>'" with timeout <%= fetch(:sidekiq_timeout).to_i + 10  %> seconds
   group <%= fetch(:sidekiq_monit_group, fetch(:application)) %>-sidekiq
 
 <% end %>


### PR DESCRIPTION
The main point of this PR is for the monit config to respect the `sidekiq_user` setting (per https://github.com/seuros/capistrano-sidekiq/issues/121#issuecomment-155222696).

It also normalizes behavior between capistrano-puma's and capistrano-sidekiq's respective `:puma_user` and `:sidekiq_user` options. (That is, if https://github.com/seuros/capistrano-puma/pull/139 is accepted.) I imagine many people use both of these gems, and IMHO this subtle difference in their behavior is non-obvious and confusing.