### PR TITLE
notice others to ensure order of required files

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ And then execute:
 ```ruby
     # Capfile
 
+    # The below two lines should below `require 'capistrano/rails'` or `require 'capistrano/bundler'` #126
     require 'capistrano/sidekiq'
     require 'capistrano/sidekiq/monit' #to require monit tasks # Only for capistrano3
 ```


### PR DESCRIPTION
add one line of comment to help others ensure commands will always be mapped to `bundle exec` prefix