### PR TITLE
Support custom monit filename

### DIFF
--- a/capistrano-sidekiq.gemspec
+++ b/capistrano-sidekiq.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'capistrano'
-  spec.add_dependency 'sidekiq', '>= 3.4'
+  spec.add_dependency 'sidekiq', '~> 4'
 end

--- a/lib/capistrano/tasks/monit.rake
+++ b/lib/capistrano/tasks/monit.rake
@@ -1,6 +1,7 @@
 namespace :load do
   task :defaults do
     set :sidekiq_monit_conf_dir, '/etc/monit/conf.d'
+    set :sidekiq_monit_conf_file, "#{sidekiq_service_name}.conf"
     set :sidekiq_monit_use_sudo, true
     set :monit_bin, '/usr/bin/monit'
     set :sidekiq_monit_default_hooks, true
@@ -30,7 +31,7 @@ namespace :sidekiq do
         @role = role
         upload_sidekiq_template 'sidekiq_monit', "#{fetch(:tmp_dir)}/monit.conf", @role
 
-        mv_command = "mv #{fetch(:tmp_dir)}/monit.conf #{fetch(:sidekiq_monit_conf_dir)}/#{sidekiq_service_name}.conf"
+        mv_command = "mv #{fetch(:tmp_dir)}/monit.conf #{fetch(:sidekiq_monit_conf_dir)}/#{fetch(:sidekiq_monit_conf_file)}"
         sudo_if_needed mv_command
 
         sudo_if_needed "#{fetch(:monit_bin)} reload"


### PR DESCRIPTION
I'm using monit-5.9 and our server config requires a custom path and extension e.g
`/usr/local/etc/monit.d/foobar-worker.monitrc` instead of *.conf file. I managed to override the custom folder path but not the file name. Hence this PR exists.

Please help reviewing. It has been manually tested.

```
set :sidekiq_monit_conf_dir, '/usr/local/etc/monit.d'
set :sidekiq_monit_conf_file, 'service-worker.monitrc'
set :monit_bin, '/usr/local/bin/monit'
```
