### PR TITLE
Add deploy failure handling to cap v2 and v3.

### DIFF
--- a/lib/capistrano/tasks/capistrano2.rb
+++ b/lib/capistrano/tasks/capistrano2.rb
@@ -102,6 +102,8 @@ Capistrano::Configuration.instance.load do
 
     desc 'Quiet sidekiq (stop accepting new work)'
     task :quiet, roles: lambda { fetch(:sidekiq_role) }, on_no_matching_servers: :continue do
+      on_rollback { sidekiq.restart }
+
       for_each_role do |sidekiq_role|
         for_each_process(sidekiq_role) do |pid_file, idx|
           quiet_process(pid_file, idx, sidekiq_role)

--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -26,6 +26,9 @@ namespace :deploy do
   after :publishing, :restart_sidekiq do
     invoke 'sidekiq:restart' if fetch(:sidekiq_default_hooks)
   end
+  after :failed, :restart_sidekiq do
+    invoke 'sidekiq:restart' if fetch(:sidekiq_default_hooks)
+  end
 end
 
 namespace :sidekiq do


### PR DESCRIPTION
This handles the case where any of the steps in the deploy process after quieting sidekiq fail, e.g. pulling from git, compiling assets, etc.

For cap v2, this is documented here: https://github.com/leehambley/capistrano-handbook/blob/master/index.markdown#transactions

For cap v3, the pull request adding support is here: https://github.com/capistrano/capistrano/pull/756.

I think this was the intention of https://github.com/seuros/capistrano-sidekiq/pull/105.