### PR TITLE
Parallelize operation on a server

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Configurable options, shown here with defaults:
 :sidekiq_options => nil
 :sidekiq_require => nil
 :sidekiq_tag => nil
-:sidekiq_config => nil # if you have a config/sidekiq.yml, do not forget to set this. 
+:sidekiq_config => nil # if you have a config/sidekiq.yml, do not forget to set this.
 :sidekiq_queue => nil
 :sidekiq_timeout => 10
 :sidekiq_role => :app
@@ -50,6 +50,7 @@ Configurable options, shown here with defaults:
 :sidekiq_cmd => "#{fetch(:bundle_cmd, "bundle")} exec sidekiq" # Only for capistrano2.5
 :sidekiqctl_cmd => "#{fetch(:bundle_cmd, "bundle")} exec sidekiqctl" # Only for capistrano2.5
 :sidekiq_user => nil #user to run sidekiq as
+:sidekiq_operation_concurrency => 0 # 0 means operation executes sequentially
 ```
 
 There is a known bug that prevents sidekiq from starting when pty is true on Capistrano 3.

--- a/capistrano-sidekiq.gemspec
+++ b/capistrano-sidekiq.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'capistrano'
   spec.add_dependency 'sidekiq', '>= 3.4'
+  spec.add_dependency 'parallel'
 end

--- a/lib/capistrano/sidekiq.rb
+++ b/lib/capistrano/sidekiq.rb
@@ -3,3 +3,4 @@ if Gem::Specification.find_by_name('capistrano').version >= Gem::Version.new('3.
 else
   require_relative 'tasks/capistrano2'
 end
+require 'parallel'

--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -10,6 +10,8 @@ namespace :load do
     set :sidekiq_processes, -> { 1 }
     set :sidekiq_options_per_process, -> { nil }
     set :sidekiq_user, -> { nil }
+    # Number of threads for command execution in each host. 0: sequentially
+    set :sidekiq_operation_concurrency, -> { 0 }
     # Rbenv, Chruby, and RVM integration
     set :rbenv_map_bins, fetch(:rbenv_map_bins).to_a.concat(%w(sidekiq sidekiqctl))
     set :rvm_map_bins, fetch(:rvm_map_bins).to_a.concat(%w(sidekiq sidekiqctl))
@@ -32,8 +34,8 @@ namespace :sidekiq do
   def for_each_process(reverse = false, &block)
     pids = processes_pids
     pids.reverse! if reverse
-    pids.each_with_index do |pid_file, idx|
-      within release_path do
+    within release_path do
+      Parallel.each_with_index(pids, in_threads: fetch(:sidekiq_operation_concurrency)) do |pid_file, idx|
         yield(pid_file, idx)
       end
     end


### PR DESCRIPTION
### Changes

This pull request adds support for parallel operation (eg: sidekiq: start) on each server.
### Motivation

Right now, operations are executed sequentially so we have to (potentially) wait longer
if we have many sidekiq processes.
### Remarks

On AWS m3.medium with 8 sidekiq processes, 
`sidekiq_operation_concurrency = 4` is the point of diminishing return.

Regards.
