### PR TITLE
Get sidekiq_pid value by reading sidekiq_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ Configurable options, shown here with defaults:
 
 ```ruby
 :sidekiq_default_hooks => true
-:sidekiq_pid => File.join(shared_path, 'tmp', 'pids', 'sidekiq.pid')
+:sidekiq_pid => File.join(shared_path, 'tmp', 'pids', 'sidekiq-0.pid') # if you specify a pidfile in your sidekiq_config file that value will be used as the default.
 :sidekiq_env => fetch(:rack_env, fetch(:rails_env, fetch(:stage)))
 :sidekiq_log => File.join(shared_path, 'log', 'sidekiq.log')
 :sidekiq_options => nil
 :sidekiq_require => nil
 :sidekiq_tag => nil
-:sidekiq_config => nil # if you have a config/sidekiq.yml, do not forget to set this. 
+:sidekiq_config => nil # if you have a config/sidekiq.yml, do not forget to set this.
 :sidekiq_queue => nil
 :sidekiq_timeout => 10
 :sidekiq_role => :app

--- a/lib/capistrano/tasks/capistrano2.rb
+++ b/lib/capistrano/tasks/capistrano2.rb
@@ -37,6 +37,7 @@ Capistrano::Configuration.instance.load do
     def for_each_process(sidekiq_role, &block)
       sidekiq_processes = fetch(:"#{ sidekiq_role }_processes") rescue 1
       sidekiq_processes.times do |idx|
+        append_idx = true
         pid_file = fetch(:sidekiq_pid)
 
         if !pid_file && fetch(:sidekiq_config)
@@ -48,11 +49,13 @@ Capistrano::Configuration.instance.load do
             end
             pid_file ||= conf[:pidfile]
           end
+
+          append_idx = false if pid_file
         end
 
         pid_file ||= File.join(shared_path, 'pids', 'sidekiq.pid')
 
-        pid_file = pid_file.gsub(/\.pid$/, "-#{idx}.pid")
+        pid_file = pid_file.gsub(/\.pid$/, "-#{idx}.pid") if append_idx
         yield(pid_file, idx)
       end
     end

--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -49,6 +49,7 @@ namespace :sidekiq do
       next unless host.roles.include?(role)
       processes = fetch(:"#{ role }_processes") || fetch(:sidekiq_processes)
       processes.times do |idx|
+        append_idx = true
         pid_file = fetch(:sidekiq_pid)
 
         if !pid_file && fetch(:sidekiq_config)
@@ -60,11 +61,13 @@ namespace :sidekiq do
             end
             pid_file ||= conf[:pidfile]
           end
+
+          append_idx = false if pid_file
         end
 
         pid_file ||= File.join(shared_path, 'tmp', 'pids', 'sidekiq.pid')
 
-        pid_file = pid_file.gsub(/\.pid$/, "-#{idx}.pid")
+        pid_file = pid_file.gsub(/\.pid$/, "-#{idx}.pid") if append_idx
         pids.push pid_file
       end
     end


### PR DESCRIPTION
Currently, even if I specify a `pidfile` value in my sidekiq.yml file, I'm forced to also set a `sidekiq_pid` value for capistrano-sidekiq. If I don't set a `sidekiq_pid` value, capistrano-sidekiq actively tells sidekiq to use capistrano-sidekiq's default pidfile location, ignoring my sidekiq.yml value.

This pull has capistrano-sidekiq pick a pidfile in the following order
1. A user-set `sidekiq_pid` value (plus any index number)
2. If a user sets a `sidekiq_config` value, any `pidfile` entry for the current `sidekiq_env`
3. If a user sets a `sidekiq_config` value, any global `pidfile` entry
4. The default pidfile location (plus any index number)

This Pull request should also address
- Issue #134 - because the value from their sidekiq.yml will be honored
- @edslocomb's problems caused by Pull #116 [[1](https://github.com/seuros/capistrano-sidekiq/pull/116#discussion_r46736675)][[2](https://github.com/seuros/capistrano-sidekiq/issues/44#issuecomment-162092207)]
- Partially addresses Issue #44 - So long a the user specifies unchanging pidfiles in the config file for each process, they'll be able to add processes as needed without worry about pidfile values changing. I'll be creating a new pull request in a bit that allows users to specify a config file per process.
