### PR TITLE
Support per-process options & better per-role options

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,11 @@ Configurable options, shown here with defaults:
 :sidekiq_concurrency => nil
 :sidekiq_monit_templates_path => 'config/deploy/templates'
 :sidekiq_monit_use_sudo => true
-:sidekiq_cmd => "#{fetch(:bundle_cmd, "bundle")} exec sidekiq" # Only for capistrano2.5
-:sidekiqctl_cmd => "#{fetch(:bundle_cmd, "bundle")} exec sidekiqctl" # Only for capistrano2.5
 :sidekiq_user => nil #user to run sidekiq as
+
+# Options only for Capistrano 2.5
+:sidekiq_cmd => "#{fetch(:bundle_cmd, "bundle")} exec sidekiq"
+:sidekiqctl_cmd => "#{fetch(:bundle_cmd, "bundle")} exec sidekiqctl"
 
 # Deprecated options
 :sidekiq_options_per_process => nil

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ Configurable options, shown here with defaults:
 
 ```ruby
 :sidekiq_default_hooks => true
-:sidekiq_pid => File.join(shared_path, 'tmp', 'pids', 'sidekiq.pid')
+:sidekiq_pid => File.join(shared_path, 'tmp', 'pids', 'sidekiq-0.pid') # if you specify a pidfile in your sidekiq_config file that value will be used as the default.
 :sidekiq_env => fetch(:rack_env, fetch(:rails_env, fetch(:stage)))
 :sidekiq_log => File.join(shared_path, 'log', 'sidekiq.log')
 :sidekiq_options => nil
 :sidekiq_require => nil
 :sidekiq_tag => nil
-:sidekiq_config => nil # if you have a config/sidekiq.yml, do not forget to set this. 
+:sidekiq_config => nil # if you have a config/sidekiq.yml, do not forget to set this.
 :sidekiq_queue => nil
 :sidekiq_timeout => 10
 :sidekiq_role => :app

--- a/README.md
+++ b/README.md
@@ -31,28 +31,36 @@ require 'capistrano/sidekiq/monit' #to require monit tasks # Only for capistrano
 Configurable options, shown here with defaults:
 
 ```ruby
-:sidekiq_default_hooks => true
+# Sidekiq options
+:sidekiq_config => nil # if you have a config/sidekiq.yml, do not forget to set this.
 :sidekiq_pid => File.join(shared_path, 'tmp', 'pids', 'sidekiq-0.pid') # if you specify a pidfile in your sidekiq_config file that value will be used as the default.
 :sidekiq_env => fetch(:rack_env, fetch(:rails_env, fetch(:stage)))
 :sidekiq_log => File.join(shared_path, 'log', 'sidekiq.log')
-:sidekiq_options => nil
 :sidekiq_require => nil
 :sidekiq_tag => nil
-:sidekiq_config => nil # if you have a config/sidekiq.yml, do not forget to set this.
 :sidekiq_queue => nil
-:sidekiq_timeout => 10
+:sidekiq_concurrency => nil
+:sidekiq_options => nil
+
+:sidekiq_timeout => 10 # Used when stopping sidekiq
+
+# Capistrano options
+:sidekiq_default_hooks => true
 :sidekiq_role => :app
 :sidekiq_processes => 1
-:sidekiq_concurrency => nil
+:sidekiq_user => nil #user to run sidekiq as
+:start_sidekiq_in_background => false
+:stop_sidekiq_in_background => false
+:sidekiq_run_in_background => false # like setting both :start_ and :stop_sidekiq_in_background to true
+:sidekiq_use_signals => false # if :stop_sidekiq_in_background is true, use signals for quite & stop
 :sidekiq_monit_templates_path => 'config/deploy/templates'
 :sidekiq_monit_use_sudo => true
-:sidekiq_user => nil #user to run sidekiq as
 
 # Options only for Capistrano 2.5
 :sidekiq_cmd => "#{fetch(:bundle_cmd, "bundle")} exec sidekiq"
 :sidekiqctl_cmd => "#{fetch(:bundle_cmd, "bundle")} exec sidekiqctl"
 
-# Deprecated options
+# Deprecated Sidekiq options
 :sidekiq_options_per_process => nil
 ```
 

--- a/lib/capistrano/tasks/capistrano2.rb
+++ b/lib/capistrano/tasks/capistrano2.rb
@@ -37,6 +37,7 @@ Capistrano::Configuration.instance.load do
     def for_each_process(sidekiq_role, &block)
       sidekiq_processes = fetch(:"#{ sidekiq_role }_processes") rescue 1
       sidekiq_processes.times do |idx|
+        append_idx = true
         pid_file = fetch(:sidekiq_pid)
 
         if !pid_file && fetch(:sidekiq_config)
@@ -48,11 +49,13 @@ Capistrano::Configuration.instance.load do
             end
             pid_file ||= conf[:pidfile]
           end
+
+          append_idx = false if pid_file
         end
 
         pid_file ||= File.join(shared_path, 'pids', 'sidekiq.pid')
 
-        pid_file = pid_file.gsub(/\.pid$/, "-#{idx}.pid")
+        pid_file = pid_file.gsub(/\.pid$/, "-#{idx}.pid") if append_idx
         yield(pid_file, idx)
       end
     end

--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -49,6 +49,7 @@ namespace :sidekiq do
       next unless host.roles.include?(role)
       processes = fetch(:"#{ role }_processes") || fetch(:sidekiq_processes)
       processes.times do |idx|
+        append_idx = true
         pid_file = fetch(:sidekiq_pid)
 
         if !pid_file && fetch(:sidekiq_config)
@@ -60,11 +61,13 @@ namespace :sidekiq do
             end
             pid_file ||= conf[:pidfile]
           end
+
+          append_idx = false if pid_file
         end
 
         pid_file ||= File.join(shared_path, 'tmp', 'pids', 'sidekiq.pid')
 
-        pid_file = pid_file.gsub(/\.pid$/, "-#{idx}.pid")
+        pid_file = pid_file.gsub(/\.pid$/, "-#{idx}.pid") if append_idx
         pids.push pid_file
       end
     end

--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -47,9 +47,13 @@ namespace :sidekiq do
     sidekiq_roles = Array(fetch(:sidekiq_role))
     sidekiq_roles.each do |role|
       next unless host.roles.include?(role)
-      processes = fetch(:"#{ role }_processes")
-      processes ||= fetch(:"sidekiq_#{ role }_processes") unless sidekiq_specific_role?(role)
-      processes ||= fetch(:sidekiq_processes)
+      # This line handles backwards-compatability
+      # where we must check the `app_processes` option
+      # to get the number of sidekiq processes for hosts with the :app role.
+      processes = fetch(:"#{ role }_processes") unless sidekiq_specific_role?(role)
+      processes ||= fetch_role_specific_values(:processes, role) do |key|
+        fetch(key)
+      end
       processes.times do |idx|
         append_idx = true
         pid_file = fetch(:sidekiq_pid)

--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -56,14 +56,14 @@ namespace :sidekiq do
       end
       processes.times do |idx|
         append_idx = true
-        pid_file = fetch(:sidekiq_pid)
+        pid_file = sidekiq_fetch(:pid, role, idx)
 
         if !pid_file && sidekiq_fetch(:config, role, idx)
           config_file = sidekiq_fetch(:config, role, idx)
           conf = YAML.load(ERB.new(IO.read(config_file)).result)
           if conf
-            if conf[fetch(:sidekiq_env).to_sym]
-              pid_file = conf[fetch(:sidekiq_env).to_sym][:pidfile]
+            if conf[sidekiq_fetch(:env, role, idx).to_sym]
+              pid_file = conf[sidekiq_fetch(:env, role, idx).to_sym][:pidfile]
             end
             pid_file ||= conf[:pidfile]
           end
@@ -118,7 +118,7 @@ namespace :sidekiq do
     args = []
     args.push "--index #{idx}"
     args.push "--pidfile #{pid_file}"
-    args.push "--environment #{fetch(:sidekiq_env)}"
+    args.push "--environment #{sidekiq_fetch(:env, role, idx)}"
     args.push "--logfile #{sidekiq_fetch(:log, role, idx)}" if sidekiq_fetch(:log, role, idx)
     args.push "--require #{sidekiq_fetch(:require, role, idx)}" if sidekiq_fetch(:require, role, idx)
     args.push "--tag #{sidekiq_fetch(:tag, role, idx)}" if sidekiq_fetch(:tag, role, idx)

--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -89,15 +89,15 @@ namespace :sidekiq do
     test(*("[ -f #{pid_file} ]").split(' '))
   end
 
-  def stop_sidekiq(pid_file)
+  def stop_sidekiq(pid_file, role, idx)
     if fetch(:stop_sidekiq_in_background, fetch(:sidekiq_run_in_background))
-      if fetch(:sidekiq_use_signals)
+      if sidekiq_fetch(:use_signals, role, idx)
         background "kill -TERM `cat #{pid_file}`"
       else
-        background :sidekiqctl, 'stop', "#{pid_file}", fetch(:sidekiq_timeout)
+        background :sidekiqctl, 'stop', "#{pid_file}", sidekiq_fetch(:timeout, role, idx)
       end
     else
-      execute :sidekiqctl, 'stop', "#{pid_file}", fetch(:sidekiq_timeout)
+      execute :sidekiqctl, 'stop', "#{pid_file}", sidekiq_fetch(:timeout, role, idx)
     end
   end
 
@@ -176,7 +176,7 @@ namespace :sidekiq do
         if test("[ -d #{release_path} ]")
           for_each_process(true) do |pid_file, idx|
             if pid_process_exists?(pid_file)
-              stop_sidekiq(pid_file)
+              stop_sidekiq(pid_file, role, idx)
             end
           end
         end

--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -122,7 +122,7 @@ namespace :sidekiq do
     args.push "--logfile #{sidekiq_fetch(:log, role, idx)}" if sidekiq_fetch(:log, role, idx)
     args.push "--require #{sidekiq_fetch(:require, role, idx)}" if sidekiq_fetch(:require, role, idx)
     args.push "--tag #{sidekiq_fetch(:tag, role, idx)}" if sidekiq_fetch(:tag, role, idx)
-    sidekiq_fetch_queue(role, idx).each do |queue|
+    Array(sidekiq_fetch_queue(role, idx)).each do |queue|
       args.push "--queue #{queue}"
     end
     args.push "--config #{sidekiq_fetch(:config, role, idx)}" if sidekiq_fetch(:config, role, idx)
@@ -301,9 +301,9 @@ namespace :sidekiq do
       # If at least one of the queues is an Array of queues
       # we assume the intention is that this is an nested Array of Arrays
       if queues.detect{ |val| val.is_a?(Array) }
-        Array(queues[idx])
+        queues[idx]
       else
-        Array(queues)
+        queues
       end
     end
   end


### PR DESCRIPTION
Note, this pull builds on top of pull #140, so includes all of its commits.
### Per-process Options

Previously, if you wanted to specify different options for multiple sidekiq processes, you'd use `:sidekiq_options_per_process`. However, because pull #140 relies knowing the path in the `:sidekiq_config`, I needed to be able to specify a different `:sidekiq_config` value for each process.

With this pull request, it's now possible to pass an Array of values to most of the sidekiq options. Any option with a non-Array value will be applied to all processes.
#### An example from the README

``` ruby
set :sidekiq_processes,  2
set :sidekiq_log, 'log/background.log'
set :sidekiq_config, [
                       'config/sidekiq/high.yml',
                       'config/sidekiq/low.yml'
                     ]
set :sidekiq_queue,  [
                       [:high],
                       [:default, :low]
                     ]
```

In this example the first process will start with the following options:
- log: 'log/background.log'
- config: 'config/sidekiq/high.yml'
- queue: 'high'

And the second sidekiq process will start with the following options:
- log: 'log/background.log'
- config: 'config/sidekiq/low.yml'
- queue: 'low' AND 'default'
### Better Per-role Options

Previously, if a user provided an Array of `:sidekiq_role` values, they could customize the `:sidekiq_processes` number per-role. However, I needed support for a different number of workers _and_ various other config differences between roles. 

With this pull request, it's now possible to set per-role options for most of the sidekiq options. If both a non-role-specific value and a role-specific value are provided, the role-specific value will be preferred. Also note that when using a role that does not contain the prefix `:sidekiq_`, the option names still retain the `:sidekiq_` prefix to avoid potential naming conflicts with other caistrano plugins.
#### An example from the README

``` ruby
set :sidekiq_role, [:web, :sidekiq_worker]
set :sidekiq_log, 'log/background.log'

set :sidekiq_web_processes, 1
set :sidekiq_web_config, 'config/sidekiq/web.yml'

set :sidekiq_worker_processes, 2
set :sidekiq_worker_config, [
                              'config/sidekiq/worker_one.yml',
                              'config/sidekiq/worker_two.yml'
                            ]

server 'web1.example.com', roles: [:web]
server 'bg1.example.com',  roles: [:sidekiq_worker]
```

In this example the web1 host will have one process with the following options:
- log: 'log/background.log'
- config: 'config/sidekiq/web.yml'

The bg1 host will have two processes. The first will have the following options:
- log: 'log/background.log'
- config: 'config/sidekiq/worker_one.yml'

The second sidekiq process on bg1 will start with the following options:
- log: 'log/background.log'
- config: 'config/sidekiq/worker_two.yml'
