### PR TITLE
update README with instructions for prepending 'bundle exec'

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ There is a known bug that prevents sidekiq from starting when pty is true on Cap
 set :pty,  false
 ```
 
+## Bundler
+
+If you'd like to prepend `bundle exec` to your sidekiq and sidekiqctl calls, modify the SSHKit command maps
+in your deploy.rb file:
+```ruby
+SSHKit.config.command_map[:sidekiq] = "bundle exec sidekiq"
+SSHKit.config.command_map[:sidekiqctl] = "bundle exec sidekiqctl"
+```
+
 ## Multiple processes
 
 You can configure sidekiq to start with multiple processes. Just set the proper amount in `sidekiq_processes`.


### PR DESCRIPTION
This PR puts a simple note on how to have capistrano-sidekiq prepend `bundle exec` to `sidekiq` and `sidekiqctl` commands post [this commit](https://github.com/seuros/capistrano-sidekiq/commit/8a49d7608e08a61a6f9d652225014565caecd982#diff-53bde90b6868f694716f646b4065f8beR118).
