### PR TITLE
Different number of processes per host another option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Configurable options, shown here with defaults:
 :sidekiq_options => nil
 :sidekiq_require => nil
 :sidekiq_tag => nil
-:sidekiq_config => nil # if you have a config/sidekiq.yml, do not forget to set this. 
+:sidekiq_config => nil # if you have a config/sidekiq.yml, do not forget to set this.
 :sidekiq_queue => nil
 :sidekiq_timeout => 10
 :sidekiq_role => :app
@@ -81,6 +81,16 @@ set :sidekiq_big_processes, 4
 server 'example-small.com', roles: [:sidekiq_small]
 server 'example-big.com', roles: [:sidekiq_big]
 ```
+
+You also can specify number of processes in server section
+
+```ruby
+set :sidekiq_processes, 5
+server 'example-default.com' # 5 processes is default setting
+server 'example-small.com', sidekiq_processes: 2
+server 'example-big.com', sidekiq_processes: 10
+```
+
 
 ## Customizing the monit sidekiq templates
 

--- a/lib/capistrano/tasks/monit.rake
+++ b/lib/capistrano/tasks/monit.rake
@@ -39,8 +39,8 @@ namespace :sidekiq do
 
     desc 'Monitor Sidekiq monit-service'
     task :monitor do
-      on roles(fetch(:sidekiq_role)) do
-        fetch(:sidekiq_processes).times do |idx|
+      on roles(fetch(:sidekiq_role)) do |role|
+        sidekiq_processes(role).times do |idx|
           begin
             sudo_if_needed "#{fetch(:monit_bin)} monitor #{sidekiq_service_name(idx)}"
           rescue
@@ -53,8 +53,8 @@ namespace :sidekiq do
 
     desc 'Unmonitor Sidekiq monit-service'
     task :unmonitor do
-      on roles(fetch(:sidekiq_role)) do
-        fetch(:sidekiq_processes).times do |idx|
+      on roles(fetch(:sidekiq_role)) do |role|
+        sidekiq_processes(role).times do |idx|
           begin
             sudo_if_needed "#{fetch(:monit_bin)} unmonitor #{sidekiq_service_name(idx)}"
           rescue
@@ -66,8 +66,8 @@ namespace :sidekiq do
 
     desc 'Start Sidekiq monit-service'
     task :start do
-      on roles(fetch(:sidekiq_role)) do
-        fetch(:sidekiq_processes).times do |idx|
+      on roles(fetch(:sidekiq_role)) do |role|
+        sidekiq_processes(role).times do |idx|
           sudo_if_needed "#{fetch(:monit_bin)} start #{sidekiq_service_name(idx)}"
         end
       end
@@ -75,8 +75,8 @@ namespace :sidekiq do
 
     desc 'Stop Sidekiq monit-service'
     task :stop do
-      on roles(fetch(:sidekiq_role)) do
-        fetch(:sidekiq_processes).times do |idx|
+      on roles(fetch(:sidekiq_role)) do |role|
+        sidekiq_processes(role).times do |idx|
           sudo_if_needed "#{fetch(:monit_bin)} stop #{sidekiq_service_name(idx)}"
         end
       end
@@ -84,11 +84,15 @@ namespace :sidekiq do
 
     desc 'Restart Sidekiq monit-service'
     task :restart do
-      on roles(fetch(:sidekiq_role)) do
-        fetch(:sidekiq_processes).times do |idx|
+      on roles(fetch(:sidekiq_role)) do |role|
+        sidekiq_processes(role).times do |idx|
           sudo_if_needed"#{fetch(:monit_bin)} restart #{sidekiq_service_name(idx)}"
         end
       end
+    end
+
+    def sidekiq_processes(role)
+      role.properties.sidekiq_processes || fetch(:sidekiq_processes).to_i
     end
 
     def sidekiq_service_name(index=nil)


### PR DESCRIPTION
Hello there. 
Guys, i really need to run different count of processes on different hosts. 
However your doc says that requested feature [is already present](https://github.com/seuros/capistrano-sidekiq#different-number-of-processes-per-host) it doesn't work for me :disappointed: 

I found [this commit](https://github.com/seuros/capistrano-sidekiq/commit/e21647ceaaac5703acb2b668ac574ff71181dd23) which added this and found [this one](https://github.com/seuros/capistrano-sidekiq/commit/574588861839a80920e681e0e9d9c52311bf8875) which, as i see, removed it back :(
Correct me if i'm wrong? 

So, guys, can we merge this one OR, fix existing, which is better of course?
Also, if i'm wrong and feature works, please can someone explain me how to use it?  
