### PR TITLE
Allow hash for sidekiq queue

### DIFF
--- a/lib/capistrano/tasks/monit.rake
+++ b/lib/capistrano/tasks/monit.rake
@@ -109,6 +109,7 @@ namespace :sidekiq do
 
     def sidekiq_queues
       Array(fetch(:sidekiq_queue)).map do |queue|
+        queue = "#{queue[0]},#{queue[1]}" if queue.is_a?(Array)
         "--queue #{queue}"
       end.join(' ')
     end

--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -95,6 +95,7 @@ namespace :sidekiq do
     args.push "--require #{fetch(:sidekiq_require)}" if fetch(:sidekiq_require)
     args.push "--tag #{fetch(:sidekiq_tag)}" if fetch(:sidekiq_tag)
     Array(fetch(:sidekiq_queue)).each do |queue|
+      queue = "#{queue[0]},#{queue[1]}" if queue.is_a?(Array)
       args.push "--queue #{queue}"
     end
     args.push "--config #{fetch(:sidekiq_config)}" if fetch(:sidekiq_config)


### PR DESCRIPTION
I think we can have more flexibility for the queue.

Either

```
# current usage
set :sidekiq_queue, ['default,1', 'low,1']
```

or

```
set :sidekiq_queue, ['default', 1], ['low', 1]]
```

or

```
set :sidekiq_queue, {default: 1, low: 1}
```

What do you think?
