### PR TITLE
Documenting sidekiq_service_name config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Configurable options, shown here with defaults:
 :sidekiq_concurrency => nil
 :sidekiq_monit_templates_path => 'config/deploy/templates'
 :sidekiq_monit_use_sudo => true
+:sidekiq_service_name => "sidekiq_#{fetch(:application)}_#{fetch(:sidekiq_env)}"
 :sidekiq_cmd => "#{fetch(:bundle_cmd, "bundle")} exec sidekiq" # Only for capistrano2.5
 :sidekiqctl_cmd => "#{fetch(:bundle_cmd, "bundle")} exec sidekiqctl" # Only for capistrano2.5
 :sidekiq_user => nil #user to run sidekiq as


### PR DESCRIPTION
This configuration option can be set with successful results but was
undocumented.

@seuros I'm currently using this setting but I'm hoping that, by documenting it, it will stick around in future versions!