### PR TITLE
Wait for Monit to be reloaded

### DIFF
--- a/lib/capistrano/tasks/monit.rake
+++ b/lib/capistrano/tasks/monit.rake
@@ -34,6 +34,8 @@ namespace :sidekiq do
         sudo_if_needed mv_command
 
         sudo_if_needed "#{fetch(:monit_bin)} reload"
+        # Wait for Monit to be reloaded
+        sleep 1
       end
     end
 


### PR DESCRIPTION
Hi @seuros.

I just started to use Monit.
I noticed that there is task `sidekiq:monit:config` which is called when there is no process to monitor.
The task reloads Monit which is fine but it seems like Monit doesn't have enough time to fully reload.
That is why I have the following error:

```
00:14 sidekiq:monit:monitor
      01 sudo /usr/bin/monit monitor sidekiq_orip_bot_staging0
      01 [sudo] password for deployer:
      01
      01 There is no service named "sidekiq_orip_bot_staging0"
      01
00:15 sidekiq:monit:config
      Uploading /tmp/monit.conf 100.0%
      01 sudo mv /tmp/monit.conf /etc/monit/conf.d/sidekiq_orip_bot_staging.conf
      01 [sudo] password for deployer:
      01
    ✔ 01 deployer@xxx.xxx.xxx.xxx 0.050s
      02 sudo /usr/bin/monit reload
      02 [sudo] password for deployer:
      02
      02 Reinitializing monit daemon
    ✔ 02 deployer@xxx.xxx.xxx.xxx 0.060s
      03 sudo /usr/bin/monit monitor sidekiq_orip_bot_staging0
      03 [sudo] password for deployer:
      03
      03 There is no service named "sidekiq_orip_bot_staging0"
(Backtrace restricted to imported tasks)
cap aborted!
SSHKit::Runner::ExecuteError: Exception while executing as deployer@xxx.xxx.xxx.xxx: sudo exit status: 1
sudo stdout: [sudo] password for deployer:
There is no service named "sidekiq_orip_bot_staging0"
sudo stderr: Nothing written

SSHKit::Command::Failed: sudo exit status: 1
sudo stdout: [sudo] password for deployer:
There is no service named "sidekiq_orip_bot_staging0"
sudo stderr: Nothing written

SSHKit::Command::Failed: sudo exit status: 1
sudo stdout: [sudo] password for deployer:
There is no service named "sidekiq_orip_bot_staging0"
sudo stderr: Nothing written

Tasks: TOP => sidekiq:monit:monitor
(See full trace by running task with --trace)
The deploy has failed with an error: Exception while executing as deployer@xxx.xxx.xxx.xxx: sudo exit status: 1
sudo stdout: [sudo] password for deployer:
There is no service named "sidekiq_orip_bot_staging0"
sudo stderr: Nothing written
```

With this little `sleep 1` Monit is getting reloaded and I have no error.
The solution seems to be dirty but it works...

What do you think?

P. S.
The same thing happens in [capistrano3-puma](https://github.com/seuros/capistrano-puma) gem.
If the solution is suitable I would provide the same PR for capistrano3-puma too.