### PR TITLE
Use new capistrano DSL for reenable tasks

### DIFF
--- a/capistrano-sidekiq.gemspec
+++ b/capistrano-sidekiq.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files`.split($/)
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'capistrano'
+  spec.add_dependency 'capistrano', '>= 3.9.0'
   spec.add_dependency 'sidekiq', '>= 3.4'
 end

--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -154,7 +154,6 @@ namespace :sidekiq do
         end
       end
     end
-    Rake::Task["sidekiq:stop"].reenable
   end
 
   desc 'Start sidekiq'
@@ -170,7 +169,7 @@ namespace :sidekiq do
 
   desc 'Restart sidekiq'
   task :restart do
-    invoke 'sidekiq:stop'
+    invoke! 'sidekiq:stop'
     invoke 'sidekiq:start'
   end
 


### PR DESCRIPTION
### Summary

After the long discussion of the issue (capistrano/capistrano#1686) related to re-enabling capistrano tasks, there was merged PR that introduced new `#invoke!`, that should resolve custom rake task re-enabling [here](https://github.com/seuros/capistrano-sidekiq/blob/master/lib/capistrano/tasks/sidekiq.rake#L157) and [capistrano-sneakers](https://github.com/inventionlabsSydney/capistrano-sneakers/blob/master/lib/capistrano/tasks/sneakers.rb#L192).

### Cross references

- inventionlabsSydney/capistrano-sneakers/pull/7