### PR TITLE
Host dependent sidekiq config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,17 @@ server 'example-small.com', roles: [:sidekiq_small]
 server 'example-big.com', roles: [:sidekiq_big]
 ```
 
+## Different configs per host
+
+You can configure what config file you want to use on each host next way:
+
+```ruby
+set :sidekiq_example_small_com_config, "config/small_sidekiq.yml"
+set :sidekiq_example_big_com_config, "config/big_sidekiq.yml"
+server 'example-small.com', roles: [:app]
+server 'example-big.com', roles: [:app]
+```
+
 ## Customizing the monit sidekiq templates
 
 If you need change some config in redactor, you can

--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -86,6 +86,14 @@ namespace :sidekiq do
     end
   end
 
+  def custom_config
+    hostname = host.hostname.gsub(/\W/, '_')
+    return if fetch(:"sidekiq_#{hostname}_config").nil? && fetch(:sidekiq_config).nil?
+    config_string = "--config "
+    return config_string + fetch(:"sidekiq_#{hostname}_config") if fetch(:"sidekiq_#{hostname}_config")
+    config_string + fetch(:sidekiq_config)
+  end
+
   def start_sidekiq(pid_file, idx = 0)
     args = []
     args.push "--index #{idx}"
@@ -97,7 +105,7 @@ namespace :sidekiq do
     Array(fetch(:sidekiq_queue)).each do |queue|
       args.push "--queue #{queue}"
     end
-    args.push "--config #{fetch(:sidekiq_config)}" if fetch(:sidekiq_config)
+    args.push custom_config
     args.push "--concurrency #{fetch(:sidekiq_concurrency)}" if fetch(:sidekiq_concurrency)
     if process_options = fetch(:sidekiq_options_per_process)
       args.push process_options[idx]


### PR DESCRIPTION
Add ability to use different sidekiq config files for different hosts.

```ruby
set :sidekiq_example_small_com_config, "config/small_sidekiq.yml"
set :sidekiq_example_big_com_config, "config/big_sidekiq.yml"
server 'example-small.com', roles: [:app]
server 'example-big.com', roles: [:app]
```
So you can split hard rare sidekiq jobs (e.g. xlsx generation via [axlsx](https://github.com/randym/axlsx)) from easy regular jobs.