### PR TITLE
Christmas Eve Cleaning 🎅 

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,14 @@ Configurable options, shown here with defaults:
 :sidekiq_options_per_process => nil
 :sidekiq_concurrency => nil
 :sidekiq_use_signals => false
+# sidekiq monit
 :sidekiq_monit_templates_path => 'config/deploy/templates'
 :sidekiq_monit_conf_dir => '/etc/monit/conf.d'
 :sidekiq_monit_use_sudo => true
 :monit_bin => '/usr/bin/monit'
 :sidekiq_monit_default_hooks => true
 :sidekiq_service_name => "sidekiq_#{fetch(:application)}_#{fetch(:sidekiq_env)}"
+
 :sidekiq_cmd => "#{fetch(:bundle_cmd, "bundle")} exec sidekiq" # Only for capistrano2.5
 :sidekiqctl_cmd => "#{fetch(:bundle_cmd, "bundle")} exec sidekiqctl" # Only for capistrano2.5
 :sidekiq_user => nil #user to run sidekiq as

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Configurable options, shown here with defaults:
 :sidekiq_processes => 1
 :sidekiq_options_per_process => nil
 :sidekiq_concurrency => nil
+:sidekiq_use_signals => false
 :sidekiq_monit_templates_path => 'config/deploy/templates'
 :sidekiq_monit_conf_dir => '/etc/monit/conf.d'
 :sidekiq_monit_use_sudo => true

--- a/lib/capistrano/sidekiq/monit.rb
+++ b/lib/capistrano/sidekiq/monit.rb
@@ -1,2 +1,1 @@
-# load monit tasks
 load File.expand_path('../../tasks/monit.rake', __FILE__)

--- a/lib/capistrano/tasks/monit.rake
+++ b/lib/capistrano/tasks/monit.rake
@@ -137,5 +137,30 @@ namespace :sidekiq do
       fetch(:sidekiq_monit_use_sudo)
     end
 
+    def upload_sidekiq_template(from, to, role)
+      template = sidekiq_template(from, role)
+      upload!(StringIO.new(ERB.new(template).result(binding)), to)
+    end
+
+    def sidekiq_template(name, role)
+      local_template_directory = fetch(:sidekiq_monit_templates_path)
+
+      search_paths = [
+        "#{name}-#{role.hostname}-#{fetch(:stage)}.erb",
+        "#{name}-#{role.hostname}.erb",
+        "#{name}-#{fetch(:stage)}.erb",
+        "#{name}.erb"
+      ].map { |filename| File.join(local_template_directory, filename) }
+
+      global_search_path = File.expand_path(
+        File.join(*%w[.. .. .. generators capistrano sidekiq monit templates], "#{name}.conf.erb"),
+        __FILE__
+      )
+
+      search_paths << global_search_path
+
+      template_path = search_paths.detect { |path| File.file?(path) }
+      File.read(template_path)
+    end
   end
 end

--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -233,30 +233,4 @@ namespace :sidekiq do
     properties.fetch(:run_as) || # global property across multiple capistrano gems
     role.user
   end
-
-  def upload_sidekiq_template(from, to, role)
-    template = sidekiq_template(from, role)
-    upload!(StringIO.new(ERB.new(template).result(binding)), to)
-  end
-
-  def sidekiq_template(name, role)
-    local_template_directory = fetch(:sidekiq_monit_templates_path)
-
-    search_paths = [
-      "#{name}-#{role.hostname}-#{fetch(:stage)}.erb",
-      "#{name}-#{role.hostname}.erb",
-      "#{name}-#{fetch(:stage)}.erb",
-      "#{name}.erb"
-    ].map { |filename| File.join(local_template_directory, filename) }
-
-    global_search_path = File.expand_path(
-      File.join(*%w[.. .. .. generators capistrano sidekiq monit templates], "#{name}.conf.erb"),
-      __FILE__
-    )
-
-    search_paths << global_search_path
-
-    template_path = search_paths.detect { |path| File.file?(path) }
-    File.read(template_path)
-  end
 end

--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -1,6 +1,7 @@
 namespace :load do
   task :defaults do
     set :sidekiq_default_hooks, -> { true }
+    set :sidekiq_use_signals, -> { false }
 
     set :sidekiq_pid, -> { File.join(shared_path, 'tmp', 'pids', 'sidekiq.pid') }
     set :sidekiq_env, -> { fetch(:rack_env, fetch(:rails_env, fetch(:stage))) }

--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -229,7 +229,7 @@ namespace :sidekiq do
 
   def sidekiq_user(role)
     properties = role.properties
-    properties.fetch(:sidekiq_user) ||               # local property for sidekiq only
+    properties.fetch(:sidekiq_user) || # local property for sidekiq only
     fetch(:sidekiq_user) ||
     properties.fetch(:run_as) || # global property across multiple capistrano gems
     role.user


### PR DESCRIPTION
🎄 Hi, thanks for the wonderful tool ❤️  

I reviewed the codebase to understand better, how `capistrano-sidekiq` works internally. And I found a couple of places that could be more clearly described.

Also I took the liberty to correct [Wiki page](https://github.com/seuros/capistrano-sidekiq/wiki/Home/_compare/d2d1bc70b1721be1681721bf1ab0b263b0814d4f...f43189ea34f06924194d9682a27b58f98c3bd4ea), because `capistrano-rails` gem doesn't imply on sidekiq deployment flow (default hooks enable inside `capistrano-sidekiq` gem itself) and `pty: false` is a Capistrano 3 default for a pretty long time.