### PR TITLE
Prepend _ Before Service Name Index

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Configurable options, shown here with defaults:
 :sidekiq_monit_use_sudo => true
 :monit_bin => '/usr/bin/monit'
 :sidekiq_monit_default_hooks => true
-:sidekiq_service_name => "sidekiq_#{fetch(:application)}_#{fetch(:sidekiq_env)}"
+:sidekiq_service_name => "sidekiq_#{fetch(:application)}_#{fetch(:sidekiq_env)}" + (index ? "_#{index}" : '') 
 
 :sidekiq_cmd => "#{fetch(:bundle_cmd, "bundle")} exec sidekiq" # Only for capistrano2.5
 :sidekiqctl_cmd => "#{fetch(:bundle_cmd, "bundle")} exec sidekiqctl" # Only for capistrano2.5

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Configurable options, shown here with defaults:
 :sidekiq_monit_use_sudo => true
 :monit_bin => '/usr/bin/monit'
 :sidekiq_monit_default_hooks => true
+:sidekiq_monit_group => nil
 :sidekiq_service_name => "sidekiq_#{fetch(:application)}_#{fetch(:sidekiq_env)}" + (index ? "_#{index}" : '') 
 
 :sidekiq_cmd => "#{fetch(:bundle_cmd, "bundle")} exec sidekiq" # Only for capistrano2.5

--- a/lib/capistrano/tasks/monit.rake
+++ b/lib/capistrano/tasks/monit.rake
@@ -92,7 +92,7 @@ namespace :sidekiq do
     end
 
     def sidekiq_service_name(index=nil)
-      fetch(:sidekiq_service_name, "sidekiq_#{fetch(:application)}_#{fetch(:sidekiq_env)}") + index.to_s
+      fetch(:sidekiq_service_name, "sidekiq_#{fetch(:application)}_#{fetch(:sidekiq_env)}") + (index ? "_#{index}" : '')
     end
 
     def sidekiq_config

--- a/lib/capistrano/tasks/monit.rake
+++ b/lib/capistrano/tasks/monit.rake
@@ -5,6 +5,7 @@ namespace :load do
     set :monit_bin, '/usr/bin/monit'
     set :sidekiq_monit_default_hooks, true
     set :sidekiq_monit_templates_path, 'config/deploy/templates'
+    set :sidekiq_monit_group, nil
   end
 end
 

--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -1,16 +1,16 @@
 namespace :load do
   task :defaults do
-    set :sidekiq_default_hooks, -> { true }
-    set :sidekiq_use_signals, -> { false }
+    set :sidekiq_default_hooks, true
+    set :sidekiq_use_signals, false
 
     set :sidekiq_pid, -> { File.join(shared_path, 'tmp', 'pids', 'sidekiq.pid') }
     set :sidekiq_env, -> { fetch(:rack_env, fetch(:rails_env, fetch(:stage))) }
     set :sidekiq_log, -> { File.join(shared_path, 'log', 'sidekiq.log') }
-    set :sidekiq_timeout, -> { 10 }
-    set :sidekiq_role, -> { :app }
-    set :sidekiq_processes, -> { 1 }
-    set :sidekiq_options_per_process, -> { nil }
-    set :sidekiq_user, -> { nil }
+    set :sidekiq_timeout, 10
+    set :sidekiq_role, :app
+    set :sidekiq_processes, 1
+    set :sidekiq_options_per_process, nil
+    set :sidekiq_user, nil
     # Rbenv, Chruby, and RVM integration
     set :rbenv_map_bins, fetch(:rbenv_map_bins).to_a.concat(%w(sidekiq sidekiqctl))
     set :rvm_map_bins, fetch(:rvm_map_bins).to_a.concat(%w(sidekiq sidekiqctl))


### PR DESCRIPTION
At the moment is not separated from the rest of the service name – `sidekiq_app_staging0`. I'd like to have the process index at the end of the service name separated by an underscore – `sidekiq_app_staging_0`.

This change will require re-configure existing sidekiq-monit setups, so probably minor version upgrade is required.

### Refactoring

- Set and describe `sidekiq_monit_group` explicitly
- Replace block calls for the scalar values