### PR TITLE
Add an option to disable monit configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Configurable options, shown here with defaults:
 :sidekiq_options => nil
 :sidekiq_require => nil
 :sidekiq_tag => nil
-:sidekiq_config => nil # if you have a config/sidekiq.yml, do not forget to set this. 
+:sidekiq_config => nil # if you have a config/sidekiq.yml, do not forget to set this.
 :sidekiq_queue => nil
 :sidekiq_timeout => 10
 :sidekiq_roles => :app
@@ -49,6 +49,7 @@ Configurable options, shown here with defaults:
 :sidekiq_monit_templates_path => 'config/deploy/templates'
 :sidekiq_monit_conf_dir => '/etc/monit/conf.d'
 :sidekiq_monit_use_sudo => true
+:sidekiq_monit_configure => true
 :monit_bin => '/usr/bin/monit'
 :sidekiq_monit_default_hooks => true
 :sidekiq_monit_group => nil
@@ -134,6 +135,12 @@ If your deploy user has no need in `sudo` for using monit, you can disable it as
 set :sidekiq_monit_use_sudo, false
 ```
 
+If monit is already configured on the server, then you can disable the
+configuration from the gem
+
+```ruby
+set :sidekiq_monit_configure, false
+```
 ## Contributing
 
 1. Fork it

--- a/lib/capistrano/tasks/monit.rake
+++ b/lib/capistrano/tasks/monit.rake
@@ -3,6 +3,7 @@ namespace :load do
     set :sidekiq_monit_conf_dir, '/etc/monit/conf.d'
     set :sidekiq_monit_conf_file, "#{sidekiq_service_name}.conf"
     set :sidekiq_monit_use_sudo, true
+    set :sidekiq_monit_configure, true
     set :monit_bin, '/usr/bin/monit'
     set :sidekiq_monit_default_hooks, true
     set :sidekiq_monit_templates_path, 'config/deploy/templates'
@@ -28,14 +29,16 @@ namespace :sidekiq do
 
     desc 'Config Sidekiq monit-service'
     task :config do
-      on roles(fetch(:sidekiq_roles)) do |role|
-        @role = role
-        upload_sidekiq_template 'sidekiq_monit', "#{fetch(:tmp_dir)}/monit.conf", @role
+      if fetch(:sidekiq_monit_configure)
+        on roles(fetch(:sidekiq_roles)) do |role|
+          @role = role
+          upload_sidekiq_template 'sidekiq_monit', "#{fetch(:tmp_dir)}/monit.conf", @role
 
-        mv_command = "mv #{fetch(:tmp_dir)}/monit.conf #{fetch(:sidekiq_monit_conf_dir)}/#{fetch(:sidekiq_monit_conf_file)}"
-        sudo_if_needed mv_command
+          mv_command = "mv #{fetch(:tmp_dir)}/monit.conf #{fetch(:sidekiq_monit_conf_dir)}/#{fetch(:sidekiq_monit_conf_file)}"
+          sudo_if_needed mv_command
 
-        sudo_if_needed "#{fetch(:monit_bin)} reload"
+          sudo_if_needed "#{fetch(:monit_bin)} reload"
+        end
       end
     end
 


### PR DESCRIPTION
Solves #181 
Allows a user to skip the monit configuration step if monit was already configured on the server