### PR TITLE
Adding advanced role management

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Configurable options, shown here with defaults:
 :sidekiq_options => nil
 :sidekiq_require => nil
 :sidekiq_tag => nil
-:sidekiq_config => nil # if you have a config/sidekiq.yml, do not forget to set this. 
+:sidekiq_config => nil # if you have a config/sidekiq.yml, do not forget to set this.
 :sidekiq_queue => nil
 :sidekiq_timeout => 10
 :sidekiq_roles => :app
@@ -52,7 +52,7 @@ Configurable options, shown here with defaults:
 :monit_bin => '/usr/bin/monit'
 :sidekiq_monit_default_hooks => true
 :sidekiq_monit_group => nil
-:sidekiq_service_name => "sidekiq_#{fetch(:application)}_#{fetch(:sidekiq_env)}" + (index ? "_#{index}" : '') 
+:sidekiq_service_name => "sidekiq_#{fetch(:application)}_#{fetch(:sidekiq_env)}" + (index ? "_#{index}" : '')
 
 :sidekiq_cmd => "#{fetch(:bundle_cmd, "bundle")} exec sidekiq" # Only for capistrano2.5
 :sidekiqctl_cmd => "#{fetch(:bundle_cmd, "bundle")} exec sidekiqctl" # Only for capistrano2.5
@@ -76,6 +76,23 @@ and `low`:
 ```ruby
 set :sidekiq_options_per_process, ["--queue high", "--queue default --queue low"]
 ```
+
+In addition, you can define a diferent schema per role:
+```ruby
+set :sidekiq_roles, [:web, :mailers, :async, :support]
+set :sidekiq_config_files_per_role, { web: ["sidekiq_web"],
+                                      mailers: ["sidekiq_mailers", "sidekiq_mailers_collect"],
+                                      async: ["sidekiq_paperclip"],
+                                      support: ["sidekiq_support"] }
+
+server '192.168.1.3', user: fetch(:user), roles: [:web, :mailers, :async]
+server '192.168.1.4', user: fetch(:user), roles: [:support, :async]
+```
+In this case, we're going to define multiple config files: `sidekiq_web.yml`, `sidekiq_mailers`....
+All of them are defined inside of `config` directory (i.ex: `config/sidekiq_web.yml`)
+
+each role can define diferent process, for example `mailers` role.
+`Mailers` role should execute a process with config file `sidekiq_mailers.yml` and other process with config file `sidekiq_mailers_collect`
 
 ## Different number of processes per role
 

--- a/lib/capistrano/sidekiq/version.rb
+++ b/lib/capistrano/sidekiq/version.rb
@@ -1,3 +1,3 @@
 module Capistrano
-  SidekiqVERSION = '1.0.0'
+  SidekiqVERSION = '1.0.1'
 end

--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -140,7 +140,7 @@ namespace :sidekiq do
   end
 
   def pid_files
-    sidekiq_roles = Array(fetch(:sidekiq_roles))
+    sidekiq_roles = Array(fetch(:sidekiq_roles)).dup
     sidekiq_roles.select! { |role| host.roles.include?(role) }
     sidekiq_roles.flat_map do |role|
       processes = fetch(:"#{ role }_processes") ||

--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -143,8 +143,10 @@ namespace :sidekiq do
     sidekiq_roles = Array(fetch(:sidekiq_roles))
     sidekiq_roles.select! { |role| host.roles.include?(role) }
     sidekiq_roles.flat_map do |role|
-      processes = fetch(:"#{ role }_processes") || fetch(:sidekiq_processes)
-      Array.new(processes) { |idx| fetch(:sidekiq_pid).gsub(/\.pid$/, "-#{idx}.pid") }
+      processes = fetch(:"#{ role }_processes") ||
+                  fetch(:sidekiq_config_files_per_role)&.dig(role)&.size ||
+                  fetch(:sidekiq_processes)
+      Array.new(processes) { |idx| fetch(:sidekiq_pid).gsub(/\.pid$/, "-#{role}-#{idx}.pid") }
     end
   end
 
@@ -180,10 +182,17 @@ namespace :sidekiq do
     Array(fetch(:sidekiq_queue)).each do |queue|
       args.push "--queue #{queue}"
     end
+
     args.push "--config #{fetch(:sidekiq_config)}" if fetch(:sidekiq_config)
     args.push "--concurrency #{fetch(:sidekiq_concurrency)}" if fetch(:sidekiq_concurrency)
     if process_options = fetch(:sidekiq_options_per_process)
       args.push process_options[idx]
+    end
+
+    if process_config_file = fetch(:sidekiq_config_files_per_role)
+      process_role = pid_file.match(/(\w+)-(\d).pid$/)[1].to_s.to_sym
+      process_id = pid_file.match(/(\w+)-(\d).pid$/)[2].to_i
+      args.push "-C #{release_path}/config/#{process_config_file[process_role][process_id]}.yml"
     end
     # use sidekiq_options for special options
     args.push fetch(:sidekiq_options) if fetch(:sidekiq_options)


### PR DESCRIPTION
**This PR adds:**
- Advanced management of roles and processes at role level.

Each server could have multiple roles.
Each role could have multiple processes.
Each process is configured by a file specified in config/process-name.yml  