### PR TITLE
fix fail rolling restart task

### DIFF
--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -89,7 +89,7 @@ namespace :sidekiq do
   task :rolling_restart do
     on roles fetch(:sidekiq_roles) do |role|
       switch_user(role) do
-        each_process_with_index(true) do |pid_file, idx|
+        each_process_with_index(reverse: true) do |pid_file, idx|
           if pid_file_exists?(pid_file) && process_exists?(pid_file)
             stop_sidekiq(pid_file)
           end


### PR DESCRIPTION
After upgrading from 0.20.0 to 1.0.0, The following errors occured

```
ArgumentError: wrong number of arguments (given 1, expected 0)
capistrano-sidekiq-1.0.0/lib/capistrano/tasks/sidekiq.rake:134:in `each_process_with_index'
capistrano-sidekiq-1.0.0/lib/capistrano/tasks/sidekiq.rake:94:in `block (4 levels) in <top (required)>'
capistrano-sidekiq-1.0.0/lib/capistrano/tasks/sidekiq.rake:206:in `switch_user'
capistrano-sidekiq-1.0.0/lib/capistrano/tasks/sidekiq.rake:91:in `block (3 levels) in <top (required)>'
```

The cause is that the argument has changed
https://github.com/seuros/capistrano-sidekiq/blob/v0.20.0/lib/capistrano/tasks/sidekiq.rake#L32
https://github.com/seuros/capistrano-sidekiq/blob/v1.0.0/lib/capistrano/tasks/sidekiq.rake#L132