### PR TITLE
Fix accounting of pidfiles per process (when using multiple processes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Support custom monit filename @zocoi
 - Systemd Integration @baierjan
 - Fix regression in sidekiq_roles variable
+- Fixed pidfile accounting per process @jsantos
+- Rubocop corrections for main task @jsantos
 
 ## 1.0.0
 
@@ -12,6 +14,7 @@
 - Convert CHANGELOG to Markdown @Tensho
 - Drop support for capistrano 2.0 @Tensho
 - *BREAKING CHANGE* If people used custom monit template, they should adjust it to use pid_files variable instead of processes_pids. @Tensho
+- *BREAKING CHANGE* `:sidekiq_role` has been renamed to its plural form, `:sidekiq_roles`
 
 ## 0.20.0
 
@@ -23,21 +26,21 @@
 - `sidekiq:stop` task perpertually callable @Tensho
 
 ## 0.5.4
- 
+
  - Add support for custom count of processes per host in monit task @okoriko
- 
+
 ## 0.5.3
- 
+
  - Custom count of processes per each host
- 
+
 ## 0.5.0
- 
+
  - Multiple processes @mrsimo
- 
+
 ## 0.3.9
- 
+
  - Restore daemon flag from Monit template
- 
+
 ## 0.3.8
 
 - Update monit template: use su instead of sudo / permit all Sidekiq options @bensie
@@ -49,59 +52,59 @@
 - Run Sidekiq as daemon from Monit @dpaluy
 
 ## 0.3.5
- 
+
 - Added `:sidekiq_tag` for capistrano 2 @OscarBarrett
- 
+
 ## 0.3.4
- 
+
 - Fix bug in `sidekiq:start` for capistrano 2 task
- 
+
 ## 0.3.3
- 
+
 - `sidekiq:restart` after `deploy:restart` added to default hooks
- 
+
 ## 0.3.2
- 
+
 - `:sidekiq_queue` accept an array
- 
+
 ## 0.3.1
- 
+
 - Fix logs @rottman
 - Add concurrency option support @ungsophy
- 
+
 ## 0.3.0
- 
+
 - Fix monit task @andreygerasimchuk
- 
+
 ## 0.2.9
- 
+
 - Check if current directory exist @alexdunae
- 
+
 ## 0.2.8
- 
+
 - Added `:sidekiq_queue` & `:sidekiq_config`
- 
+
 ## 0.2.7
- 
+
 - Signal usage @penso
- 
+
 ## 0.2.6
- 
+
 - `sidekiq:start` check if sidekiq is running
- 
+
 ## 0.2.5
- 
+
 - Bug fixes
- 
+
 ## 0.2.4
- 
+
 - Fast deploy with `:sidekiq_run_in_background`
- 
+
 ## 0.2.3
- 
+
 - Added monit tasks (alpha)
- 
+
 ## 0.2.0
- 
+
 - Added `sidekiq:rolling_restart` @jlecour
- 
+


### PR DESCRIPTION
Fixes #191 

This regression was introduced by #190, due to a minor refactor on the method to retrieve the pidfiles for a particular host's roles. 

In sum, the `sidekiq_roles` variable was being mutated by a `.reject!` statement and would only work properly for the first method call (for more context check the corresponding issue).

I took the liberty to do a few styling corrections, suggested by Rubocop. Also included the breaking change from `sidekiq_role` to `sidekiq_roles` that happened on `1.0.0` to the corresponding changelog entry.