### PR TITLE
[WIP] Sidekiq Monit Service Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ And then execute:
 
 
 ## Usage
+
 ```ruby
 # Capfile
 require 'capistrano/sidekiq'
-require 'capistrano/sidekiq/monit' #to require monit tasks # Only for capistrano3
+require 'capistrano/sidekiq/monit' # optional require of the monit tasks
 ```
-
 
 Configurable options, shown here with defaults:
 
@@ -38,7 +38,7 @@ Configurable options, shown here with defaults:
 :sidekiq_options => nil
 :sidekiq_require => nil
 :sidekiq_tag => nil
-:sidekiq_config => nil # if you have a config/sidekiq.yml, do not forget to set this. 
+:sidekiq_config => nil # if you have a config/sidekiq.yml, do not forget to set this.
 :sidekiq_queue => nil
 :sidekiq_timeout => 10
 :sidekiq_roles => :app
@@ -46,13 +46,13 @@ Configurable options, shown here with defaults:
 :sidekiq_options_per_process => nil
 :sidekiq_concurrency => nil
 # sidekiq monit
+:monit_bin => '/usr/bin/monit'
 :sidekiq_monit_templates_path => 'config/deploy/templates'
 :sidekiq_monit_conf_dir => '/etc/monit/conf.d'
 :sidekiq_monit_use_sudo => true
-:monit_bin => '/usr/bin/monit'
 :sidekiq_monit_default_hooks => true
 :sidekiq_monit_group => nil
-:sidekiq_service_name => "sidekiq_#{fetch(:application)}_#{fetch(:sidekiq_env)}" + (index ? "_#{index}" : '') 
+:sidekiq_monit_service_name => "sidekiq_#{fetch(:application)}_#{fetch(:sidekiq_env)}" + (index ? "_#{index}" : '')
 
 :sidekiq_cmd => "#{fetch(:bundle_cmd, "bundle")} exec sidekiq" # Only for capistrano2.5
 :sidekiqctl_cmd => "#{fetch(:bundle_cmd, "bundle")} exec sidekiqctl" # Only for capistrano2.5

--- a/capistrano-sidekiq.gemspec
+++ b/capistrano-sidekiq.gemspec
@@ -5,7 +5,7 @@ require 'capistrano/sidekiq/version'
 
 Gem::Specification.new do |spec|
   spec.name = 'capistrano-sidekiq'
-  spec.version = Capistrano::SidekiqVERSION
+  spec.version = Capistrano::Sidekiq::VERSION
   spec.authors = ['Abdelkader Boudih']
   spec.email = ['terminale@gmail.com']
   spec.summary = %q{Sidekiq integration for Capistrano}

--- a/lib/capistrano/sidekiq/version.rb
+++ b/lib/capistrano/sidekiq/version.rb
@@ -1,3 +1,5 @@
 module Capistrano
-  SidekiqVERSION = '1.0.0'
+  module Sidekiq
+    VERSION = '1.0.0'
+  end
 end

--- a/lib/generators/capistrano/sidekiq/monit/templates/sidekiq_monit.conf.erb
+++ b/lib/generators/capistrano/sidekiq/monit/templates/sidekiq_monit.conf.erb
@@ -1,6 +1,6 @@
 # Monit configuration for Sidekiq :  <%= fetch(:application) %>
 <% pid_files.each_with_index do |pid_file, idx| %>
-check process <%= sidekiq_service_name(idx) %>
+check process <%= sidekiq_monit_service_name(idx) %>
   with pidfile "<%= pid_file %>"
   start program = "/bin/su - <%= sidekiq_user(@role) %> -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:sidekiq] %> <%= sidekiq_config %> --index <%= idx %> --pidfile <%= pid_file %> --environment <%= fetch(:sidekiq_env) %> <%= sidekiq_concurrency %> <%= sidekiq_logfile %> <%= sidekiq_require %> <%= sidekiq_queues %> <%= sidekiq_options_per_process[idx] %> -d'" with timeout 30 seconds
 

--- a/lib/generators/capistrano/sidekiq/monit/templates/sidekiq_monit.conf.erb
+++ b/lib/generators/capistrano/sidekiq/monit/templates/sidekiq_monit.conf.erb
@@ -6,5 +6,4 @@ check process <%= sidekiq_monit_service_name(idx) %>
 
   stop program = "/bin/su - <%= sidekiq_user(@role) %> -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:sidekiqctl] %> stop <%= pid_file %>'" with timeout <%= fetch(:sidekiq_timeout).to_i + 10  %> seconds
   group <%= fetch(:sidekiq_monit_group, fetch(:application)) %>-sidekiq
-
 <% end %>


### PR DESCRIPTION
Replaced `sidekiq_service_name` with `sidekiq_monit_service_name`. It's worth to emphasize service name is used exclusively in monit setup.