### PR TITLE
Fix monit config file name missing application

### DIFF
--- a/lib/capistrano/tasks/monit.rake
+++ b/lib/capistrano/tasks/monit.rake
@@ -1,7 +1,7 @@
 namespace :load do
   task :defaults do
     set :sidekiq_monit_conf_dir, '/etc/monit/conf.d'
-    set :sidekiq_monit_conf_file, "#{sidekiq_service_name}.conf"
+    set :sidekiq_monit_conf_file, -> { "#{sidekiq_service_name}.conf" }
     set :sidekiq_monit_use_sudo, true
     set :monit_bin, '/usr/bin/monit'
     set :sidekiq_monit_default_hooks, true

--- a/lib/generators/capistrano/sidekiq/monit/templates/sidekiq_monit.conf.erb
+++ b/lib/generators/capistrano/sidekiq/monit/templates/sidekiq_monit.conf.erb
@@ -5,6 +5,6 @@ check process <%= sidekiq_service_name(idx) %>
   start program = "/bin/su - <%= sidekiq_user(@role) %> -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:sidekiq] %> <%= sidekiq_config %> --index <%= idx %> --pidfile <%= pid_file %> --environment <%= fetch(:sidekiq_env) %> <%= sidekiq_concurrency %> <%= sidekiq_logfile %> <%= sidekiq_require %> <%= sidekiq_queues %> <%= sidekiq_options_per_process[idx] %> -d'" with timeout 30 seconds
 
   stop program = "/bin/su - <%= sidekiq_user(@role) %> -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:sidekiqctl] %> stop <%= pid_file %>'" with timeout <%= fetch(:sidekiq_timeout).to_i + 10  %> seconds
-  group <%= fetch(:sidekiq_monit_group, fetch(:application)) %>-sidekiq
+  group <%= fetch(:sidekiq_monit_group) || fetch(:application) %>-sidekiq
 
 <% end %>


### PR DESCRIPTION
1.sidekiq_service_name cann't fetch application at initialization phase.Using block works.
2.replace `fetch(:sidekiq_monit_group, fetch(:application)` with `fetch(:sidekiq_monit_group) || fetch(:application)`

see issue  https://github.com/seuros/capistrano-sidekiq/issues/204