### PR TITLE
Ability to set a different configuration file per role.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,18 @@ server 'example-small.com', roles: [:sidekiq_small]
 server 'example-big.com', roles: [:sidekiq_big]
 ```
 
+## Different configuration files per role
+
+You can configure a different configuration file per role, all the process in this role will use the same file.
+
+```ruby
+set :sidekiq_roles, [:sidekiq_small, :sidekiq_big]
+set :sidekiq_small_config, "#{current_path}/config/sidekiq/sidekiq_light_jobs.yml"
+set :sidekiq_common_config, "#{current_path}/config/sidekiq/sidekiq_heavy_jobs.yml"
+server 'example-small.com', roles: [:sidekiq_small]
+server 'example-big.com', roles: [:sidekiq_big]
+```
+
 ## Integration with systemd
 
 Set init system to systemd in the cap deploy config:

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ You can configure a different configuration file per role, all the process in th
 ```ruby
 set :sidekiq_roles, [:sidekiq_small, :sidekiq_big]
 set :sidekiq_small_config, "#{current_path}/config/sidekiq/sidekiq_light_jobs.yml"
-set :sidekiq_common_config, "#{current_path}/config/sidekiq/sidekiq_heavy_jobs.yml"
+set :sidekiq_big_config, "#{current_path}/config/sidekiq/sidekiq_heavy_jobs.yml"
 server 'example-small.com', roles: [:sidekiq_small]
 server 'example-big.com', roles: [:sidekiq_big]
 ```

--- a/lib/capistrano/sidekiq/version.rb
+++ b/lib/capistrano/sidekiq/version.rb
@@ -1,3 +1,3 @@
 module Capistrano
-  SidekiqVERSION = '1.0.2'
+  SidekiqVERSION = '1.0.3'
 end

--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -87,7 +87,7 @@ namespace :sidekiq do
         else
           each_process_with_index do |pid_file, idx|
             unless pid_file_exists?(pid_file) && process_exists?(pid_file)
-              start_sidekiq(pid_file, idx)
+              start_sidekiq(role, pid_file, idx)
             end
           end
         end
@@ -109,7 +109,7 @@ namespace :sidekiq do
           if pid_file_exists?(pid_file) && process_exists?(pid_file)
             stop_sidekiq(pid_file)
           end
-          start_sidekiq(pid_file, idx)
+          start_sidekiq(role, pid_file, idx)
         end
       end
     end
@@ -136,7 +136,7 @@ namespace :sidekiq do
     on roles fetch(:sidekiq_roles) do |role|
       switch_user(role) do
         each_process_with_index do |pid_file, idx|
-          start_sidekiq(pid_file, idx) unless pid_file_exists?(pid_file)
+          start_sidekiq(role, pid_file, idx) unless pid_file_exists?(pid_file)
         end
       end
     end
@@ -229,7 +229,7 @@ namespace :sidekiq do
     execute :sidekiqctl, 'stop', pid_file.to_s, fetch(:sidekiq_timeout)
   end
 
-  def start_sidekiq(pid_file, idx = 0)
+  def start_sidekiq(role, pid_file, idx = 0)
     args = []
     args.push "--index #{idx}"
     args.push "--pidfile #{pid_file}"
@@ -240,7 +240,8 @@ namespace :sidekiq do
     Array(fetch(:sidekiq_queue)).each do |queue|
       args.push "--queue #{queue}"
     end
-    args.push "--config #{fetch(:sidekiq_config)}" if fetch(:sidekiq_config)
+    config_file = sidekiq_config(role)
+    args.push "--config #{config_file}" if config_file
     args.push "--concurrency #{fetch(:sidekiq_concurrency)}" if fetch(:sidekiq_concurrency)
     if (process_options = fetch(:sidekiq_options_per_process))
       args.push process_options[idx]
@@ -275,5 +276,11 @@ namespace :sidekiq do
       fetch(:sidekiq_user) ||
       properties.fetch(:run_as) || # global property across multiple capistrano gems
       role.user
+  end
+
+  def sidekiq_config(role)
+    sidekiq_roles = Array.wrap(fetch(:sidekiq_roles)) || []
+    role_name = role.roles_array.find { |role_name| sidekiq_roles.include?(role_name) }
+    fetch(:"#{role_name}_config") || fetch(:sidekiq_config)
   end
 end


### PR DESCRIPTION
Added role as a parameter of the start method, it will try to check if there was a specific config set for the given role using the convention `#{role_name}_config` otherwise will check the default `:sidekiq_config.`

it brings the capability to have different roles processing a separated set of queues from the config. i use this so I can isolate heavier queues such exports on their own infrastructure.

I hope this makes sense to be in the core. 