### PR TITLE
Update README#Multiple processes example

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ This example should boot the first process with the queue `high` and the second 
 and `low`:
 
 ```ruby
+set :sidekiq_processes, 2
 set :sidekiq_options_per_process, ["--queue high", "--queue default --queue low"]
 ```
 


### PR DESCRIPTION
Without adjusting the process number the configured second queue will never be started.

Indicating this in the REAMDE might keep others from making the same mistake.