### PR TITLE
Add sidekiq_service_unit_env_vars option to pass Environment variable…

### DIFF
--- a/lib/generators/capistrano/sidekiq/systemd/templates/sidekiq.service.capistrano.erb
+++ b/lib/generators/capistrano/sidekiq/systemd/templates/sidekiq.service.capistrano.erb
@@ -11,6 +11,10 @@ ExecStop=/bin/kill -TERM $MAINPID
 <%="User=#{sidekiq_user}" if sidekiq_user %>
 <%="EnvironmentFile=#{fetch(:sidekiq_service_unit_env_file)}" if fetch(:sidekiq_service_unit_env_file) %>
 
+<% fetch(:sidekiq_service_unit_env_vars, []).each do |environment_variable| %>
+  <%="Environment=#{environment_variable}" %>
+<% end %>
+
 RestartSec=1
 Restart=on-failure
 


### PR DESCRIPTION
…s to systemd config file.

I'm using RBENV. And this guy requires some variables to run.

Usage example:

```
SSHKit.config.command_map[:bundler] = "#{fetch(:rbenv_path)}/bin/rbenv exec bundler"
set :sidekiq_service_unit_env_vars, [
  "RBENV_VERSION=#{fetch(:rbenv_ruby)}",
  "RBENV_ROOT=#{fetch(:rbenv_path)}"
]
```

Now after `bundle exec cap production sidekiq:install` proper config will be generated.

```
  ExecStart=/usr/local/rbenv/bin/rbenv exec bundler exec sidekiq -e production....
  Environment=RBENV_VERSION=2.7.1
  Environment=RBENV_ROOT=/usr/local/rbenv
```