### PR TITLE
Add "loginctl enable-linger" command to sidekiq systemd install task

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Configurable options, shown here with defaults:
 :sidekiq_env => fetch(:rack_env, fetch(:rails_env, fetch(:stage)))
 :sidekiq_log => File.join(shared_path, 'log', 'sidekiq.log')
 
+# sidekiq systemd options
+:sidekiq_service_unit_name => 'sidekiq'
+:sidekiq_service_unit_user => :user # :system
+:sidekiq_enable_lingering => true
+:sidekiq_lingering_user => nil
+
 # sidekiq monit
 :sidekiq_monit_templates_path => 'config/deploy/templates'
 :sidekiq_monit_conf_dir => '/etc/monit/conf.d'

--- a/lib/capistrano/sidekiq/systemd.rb
+++ b/lib/capistrano/sidekiq/systemd.rb
@@ -3,6 +3,8 @@ module Capistrano
     def set_defaults
       set_if_empty :sidekiq_service_unit_name, 'sidekiq'
       set_if_empty :sidekiq_service_unit_user, :user # :system
+      set_if_empty :sidekiq_enable_lingering, true
+      set_if_empty :sidekiq_lingering_user, nil
     end
 
     def define_tasks

--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -49,6 +49,7 @@ namespace :sidekiq do
           execute :sudo, :systemctl, "enable", fetch(:sidekiq_service_unit_name)
         else
           execute :systemctl, "--user", "enable", fetch(:sidekiq_service_unit_name)
+          execute :loginctl, "enable-linger"
         end
       end
     end

--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -49,7 +49,7 @@ namespace :sidekiq do
           execute :sudo, :systemctl, "enable", fetch(:sidekiq_service_unit_name)
         else
           execute :systemctl, "--user", "enable", fetch(:sidekiq_service_unit_name)
-          execute :loginctl, "enable-linger"
+          execute :loginctl, "enable-linger", fetch(:sidekiq_lingering_user) if fetch(:sidekiq_enable_lingering)
         end
       end
     end


### PR DESCRIPTION
Without lingering sidekiq systemd process will be shutdown.

> The systemd user instance is started after the first login of a user and killed after the last session of the user is closed. Sometimes it may be useful to start it right after boot, and keep the systemd user instance running after the last session closes, for instance to have some user process running without any open session. Lingering is used to that effect. 

From https://wiki.archlinux.org/index.php/Systemd/User

By default `loginctl enable-linger` enables lingering for current user. We can add variable if needed.