### PR TITLE
Capistrano rbenv uses bundle instead of bundler

### DIFF
--- a/lib/generators/capistrano/sidekiq/systemd/templates/sidekiq.service.capistrano.erb
+++ b/lib/generators/capistrano/sidekiq/systemd/templates/sidekiq.service.capistrano.erb
@@ -5,7 +5,7 @@ After=syslog.target network.target
 [Service]
 Type=simple
 WorkingDirectory=<%= File.join(fetch(:deploy_to), 'current') %>
-ExecStart=<%= SSHKit.config.command_map[:bundler] %> exec sidekiq -e <%= fetch(:sidekiq_env) %>
+ExecStart=<%= SSHKit.config.command_map[:bundle] %> exec sidekiq -e <%= fetch(:sidekiq_env) %>
 ExecReload=/bin/kill -TSTP $MAINPID
 ExecStop=/bin/kill -TERM $MAINPID
 <%="StandardOutput=append:#{fetch(:sidekiq_log)}" if fetch(:sidekiq_log) %>


### PR DESCRIPTION
Capistrano rbenv and other similar tools use **bundle exec** instead of **bundler exec**. So they  map SSHKit.config.command_map[:bundle] instead of SSHKit.config.command_map[:bundler].