### PR TITLE
Systemd update

### DIFF
--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -19,9 +19,9 @@ namespace :sidekiq do
     on roles fetch(:sidekiq_roles) do |role|
       git_plugin.switch_user(role) do
         if fetch(:sidekiq_service_unit_user) == :system
-          execute :sudo, :systemctl, "stop", fetch(:sidekiq_service_unit_name)
+          execute :sudo, :systemctl, "stop", fetch(:sidekiq_service_unit_name), raise_on_non_zero_exit: false
         else
-          execute :systemctl, "--user", "stop", fetch(:sidekiq_service_unit_name)
+          execute :systemctl, "--user", "stop", fetch(:sidekiq_service_unit_name), raise_on_non_zero_exit: false
         end
       end
     end

--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -31,10 +31,19 @@ namespace :sidekiq do
   task :start do
     on roles fetch(:sidekiq_roles) do |role|
       git_plugin.switch_user(role) do
-        if fetch(:sidekiq_service_unit_user) == :system
-          execute :sudo, :systemctl, 'start', fetch(:sidekiq_service_unit_name)
-        else
-          execute :systemctl, '--user', 'start', fetch(:sidekiq_service_unit_name)
+        begin
+          if fetch(:sidekiq_service_unit_user) == :system
+            execute :sudo, :systemctl, 'start', fetch(:sidekiq_service_unit_name)
+          else
+            execute :systemctl, '--user', 'start', fetch(:sidekiq_service_unit_name)
+          end
+        rescue
+          invoke 'sidekiq:install'
+          if fetch(:sidekiq_service_unit_user) == :system
+            execute :sudo, :systemctl, 'start', fetch(:sidekiq_service_unit_name)
+          else
+            execute :systemctl, '--user', 'start', fetch(:sidekiq_service_unit_name)
+          end
         end
       end
     end


### PR DESCRIPTION
This update ignores stop errors when systemd service is not running, which prevents Capistrano from completing the deployment.