### PR TITLE
Update monit integration against Sidekiq 6.0

### DIFF
--- a/lib/capistrano/tasks/monit.rake
+++ b/lib/capistrano/tasks/monit.rake
@@ -1,14 +1,4 @@
-namespace :load do
-  task :defaults do
-    set :sidekiq_monit_conf_dir, '/etc/monit/conf.d'
-    set :sidekiq_monit_conf_file, -> { "#{sidekiq_service_name}.conf" }
-    set :sidekiq_monit_use_sudo, true
-    set :monit_bin, '/usr/bin/monit'
-    set :sidekiq_monit_default_hooks, true
-    set :sidekiq_monit_templates_path, 'config/deploy/templates'
-    set :sidekiq_monit_group, nil
-  end
-end
+git_plugin = self
 
 namespace :deploy do
   before :starting, :check_sidekiq_monit_hooks do
@@ -20,7 +10,6 @@ end
 
 namespace :sidekiq do
   namespace :monit do
-
     task :add_default_hooks do
       before 'deploy:updating',  'sidekiq:monit:unmonitor'
       after  'deploy:published', 'sidekiq:monit:monitor'
@@ -30,24 +19,26 @@ namespace :sidekiq do
     task :config do
       on roles(fetch(:sidekiq_roles)) do |role|
         @role = role
-        upload_sidekiq_template 'sidekiq_monit', "#{fetch(:tmp_dir)}/monit.conf", @role
-
-        mv_command = "mv #{fetch(:tmp_dir)}/monit.conf #{fetch(:sidekiq_monit_conf_dir)}/#{fetch(:sidekiq_monit_conf_file)}"
-        sudo_if_needed mv_command
-
-        sudo_if_needed "#{fetch(:monit_bin)} reload"
+        git_plugin.upload_sidekiq_template 'sidekiq_monit', "#{fetch(:tmp_dir)}/monit.conf", @role
+  
+        git_plugin.switch_user(role) do
+          mv_command = "mv #{fetch(:tmp_dir)}/monit.conf #{fetch(:sidekiq_monit_conf_dir)}/#{fetch(:sidekiq_monit_conf_file)}"
+  
+          git_plugin.sudo_if_needed mv_command
+          git_plugin.sudo_if_needed "#{fetch(:monit_bin)} reload"
+        end
       end
     end
 
     desc 'Monitor Sidekiq monit-service'
     task :monitor do
-      on roles(fetch(:sidekiq_roles)) do
-        fetch(:sidekiq_processes).times do |idx|
+      on roles(fetch(:sidekiq_roles)) do |role|
+        git_plugin.switch_user(role) do
           begin
-            sudo_if_needed "#{fetch(:monit_bin)} monitor #{sidekiq_service_name(idx)}"
+            git_plugin.sudo_if_needed "#{fetch(:monit_bin)} monitor #{git_plugin.sidekiq_service_name}"
           rescue
             invoke 'sidekiq:monit:config'
-            sudo_if_needed "#{fetch(:monit_bin)} monitor #{sidekiq_service_name(idx)}"
+            git_plugin.sudo_if_needed "#{fetch(:monit_bin)} monitor #{git_plugin.sidekiq_service_name}"
           end
         end
       end
@@ -55,114 +46,133 @@ namespace :sidekiq do
 
     desc 'Unmonitor Sidekiq monit-service'
     task :unmonitor do
-      on roles(fetch(:sidekiq_roles)) do
-        fetch(:sidekiq_processes).times do |idx|
+      on roles(fetch(:sidekiq_roles)) do |role|
+        git_plugin.switch_user(role) do
           begin
-            sudo_if_needed "#{fetch(:monit_bin)} unmonitor #{sidekiq_service_name(idx)}"
+            git_plugin.sudo_if_needed "#{fetch(:monit_bin)} unmonitor #{git_plugin.sidekiq_service_name}"
           rescue
             # no worries here
           end
         end
       end
     end
+  end
 
-    desc 'Start Sidekiq monit-service'
-    task :start do
-      on roles(fetch(:sidekiq_roles)) do
-        fetch(:sidekiq_processes).times do |idx|
-          sudo_if_needed "#{fetch(:monit_bin)} start #{sidekiq_service_name(idx)}"
-        end
+  desc 'Start Sidekiq monit-service'
+  task :start do
+    on roles(fetch(:sidekiq_roles)) do |role|
+      git_plugin.switch_user(role) do
+        git_plugin.sudo_if_needed "#{fetch(:monit_bin)} start #{git_plugin.sidekiq_service_name}"
       end
     end
+  end
 
-    desc 'Stop Sidekiq monit-service'
-    task :stop do
-      on roles(fetch(:sidekiq_roles)) do
-        fetch(:sidekiq_processes).times do |idx|
-          sudo_if_needed "#{fetch(:monit_bin)} stop #{sidekiq_service_name(idx)}"
-        end
+  desc 'Stop Sidekiq monit-service'
+  task :stop do
+    on roles(fetch(:sidekiq_roles)) do |role|
+      git_plugin.switch_user(role) do
+        git_plugin.sudo_if_needed "#{fetch(:monit_bin)} stop #{git_plugin.sidekiq_service_name}"
       end
     end
+  end
 
-    desc 'Restart Sidekiq monit-service'
-    task :restart do
-      on roles(fetch(:sidekiq_roles)) do
-        fetch(:sidekiq_processes).times do |idx|
-          sudo_if_needed"#{fetch(:monit_bin)} restart #{sidekiq_service_name(idx)}"
-        end
+  desc 'Restart Sidekiq monit-service'
+  task :restart do
+    on roles(fetch(:sidekiq_roles)) do |role|
+      git_plugin.sudo_if_needed "#{fetch(:monit_bin)} restart #{git_plugin.sidekiq_service_name}"
+    end
+  end
+
+  def sidekiq_service_name
+    fetch(:sidekiq_service_name, "sidekiq_#{fetch(:application)}_#{fetch(:sidekiq_env)}")
+  end
+
+  def sidekiq_config
+    if fetch(:sidekiq_config)
+      "--config #{fetch(:sidekiq_config)}"
+    end
+  end
+
+  def sidekiq_concurrency
+    if fetch(:sidekiq_concurrency)
+      "--concurrency #{fetch(:sidekiq_concurrency)}"
+    end
+  end
+
+  def sidekiq_queues
+    Array(fetch(:sidekiq_queue)).map do |queue|
+      "--queue #{queue}"
+    end.join(' ')
+  end
+
+  def sidekiq_logfile
+    fetch(:sidekiq_log)
+  end
+
+  def sidekiq_require
+    if fetch(:sidekiq_require)
+      "--require #{fetch(:sidekiq_require)}"
+    end
+  end
+
+  def switch_user(role)
+    su_user = sidekiq_user(role)
+    if su_user != role.user
+      yield
+    else
+      backend.as su_user do
+        yield
       end
     end
+  end
 
-    def sidekiq_service_name(index=nil)
-      fetch(:sidekiq_service_name, "sidekiq_#{fetch(:application)}_#{fetch(:sidekiq_env)}") + (index ? "_#{index}" : '')
+  def sidekiq_user(role = nil)
+    if role.nil?
+      fetch(:sidekiq_user)
+    else
+      properties = role.properties
+      properties.fetch(:sidekiq_user) ||
+        fetch(:sidekiq_user) ||
+        properties.fetch(:run_as) ||
+        role.user
     end
+  end
 
-    def sidekiq_config
-      if fetch(:sidekiq_config)
-        "--config #{fetch(:sidekiq_config)}"
-      end
+  def sudo_if_needed(command)
+    if use_sudo?
+      backend.execute :sudo, command
+    else
+      backend.execute command
     end
+  end
 
-    def sidekiq_concurrency
-      if fetch(:sidekiq_concurrency)
-        "--concurrency #{fetch(:sidekiq_concurrency)}"
-      end
-    end
+  def use_sudo?
+    fetch(:sidekiq_monit_use_sudo)
+  end
 
-    def sidekiq_queues
-      Array(fetch(:sidekiq_queue)).map do |queue|
-        "--queue #{queue}"
-      end.join(' ')
-    end
+  def upload_sidekiq_template(from, to, role)
+    template = sidekiq_template(from, role)
+    backend.upload!(StringIO.new(ERB.new(template).result(binding)), to)
+  end
 
-    def sidekiq_logfile
-      if fetch(:sidekiq_log)
-        "--logfile #{fetch(:sidekiq_log)}"
-      end
-    end
+  def sidekiq_template(name, role)
+    local_template_directory = fetch(:sidekiq_monit_templates_path)
 
-    def sidekiq_require
-      if fetch(:sidekiq_require)
-        "--require #{fetch(:sidekiq_require)}"
-      end
-    end
+    search_paths = [
+      "#{name}-#{role.hostname}-#{fetch(:stage)}.erb",
+      "#{name}-#{role.hostname}.erb",
+      "#{name}-#{fetch(:stage)}.erb",
+      "#{name}.erb"
+    ].map { |filename| File.join(local_template_directory, filename) }
 
-    def sidekiq_options_per_process
-      fetch(:sidekiq_options_per_process) || []
-    end
+    global_search_path = File.expand_path(
+      File.join(*%w[.. .. .. generators capistrano sidekiq monit templates], "#{name}.conf.erb"),
+      __FILE__
+    )
 
-    def sudo_if_needed(command)
-      send(use_sudo? ? :sudo : :execute, command)
-    end
+    search_paths << global_search_path
 
-    def use_sudo?
-      fetch(:sidekiq_monit_use_sudo)
-    end
-
-    def upload_sidekiq_template(from, to, role)
-      template = sidekiq_template(from, role)
-      upload!(StringIO.new(ERB.new(template).result(binding)), to)
-    end
-
-    def sidekiq_template(name, role)
-      local_template_directory = fetch(:sidekiq_monit_templates_path)
-
-      search_paths = [
-        "#{name}-#{role.hostname}-#{fetch(:stage)}.erb",
-        "#{name}-#{role.hostname}.erb",
-        "#{name}-#{fetch(:stage)}.erb",
-        "#{name}.erb"
-      ].map { |filename| File.join(local_template_directory, filename) }
-
-      global_search_path = File.expand_path(
-        File.join(*%w[.. .. .. generators capistrano sidekiq monit templates], "#{name}.conf.erb"),
-        __FILE__
-      )
-
-      search_paths << global_search_path
-
-      template_path = search_paths.detect { |path| File.file?(path) }
-      File.read(template_path)
-    end
+    template_path = search_paths.detect { |path| File.file?(path) }
+    File.read(template_path)
   end
 end

--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -6,7 +6,7 @@ end
 
 namespace :sidekiq do
   task :add_default_hooks do
-    after 'deploy:starting', 'sidekiq:quiet'
+    after 'deploy:starting', 'sidekiq:quiet' if Rake::Task.task_defined?('sidekiq:quiet')
     after 'deploy:updated', 'sidekiq:stop'
     after 'deploy:published', 'sidekiq:start'
     after 'deploy:failed', 'sidekiq:restart'

--- a/lib/generators/capistrano/sidekiq/monit/templates/sidekiq_monit.conf.erb
+++ b/lib/generators/capistrano/sidekiq/monit/templates/sidekiq_monit.conf.erb
@@ -1,10 +1,6 @@
 # Monit configuration for Sidekiq :  <%= fetch(:application) %>
-<% pid_files.each_with_index do |pid_file, idx| %>
-check process <%= sidekiq_service_name(idx) %>
-  with pidfile "<%= pid_file %>"
-  start program = "/bin/su - <%= sidekiq_user(@role) %> -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:sidekiq] %> <%= sidekiq_config %> --index <%= idx %> --pidfile <%= pid_file %> --environment <%= fetch(:sidekiq_env) %> <%= sidekiq_concurrency %> <%= sidekiq_logfile %> <%= sidekiq_require %> <%= sidekiq_queues %> <%= sidekiq_options_per_process[idx] %> -d'" with timeout 30 seconds
-
-  stop program = "/bin/su - <%= sidekiq_user(@role) %> -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:sidekiqctl] %> stop <%= pid_file %>'" with timeout <%= fetch(:sidekiq_timeout).to_i + 10  %> seconds
+  check process <%= sidekiq_service_name %>
+  matching 'sidekiq .* <%= fetch(:full_app_name) %>'
+  start program = "/bin/su - <%= sidekiq_user(role) %> -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:bundle] %> exec sidekiq -e <%= fetch(:sidekiq_env) %> <%= sidekiq_config %> <%= sidekiq_concurrency %> <%= sidekiq_require %> <%= sidekiq_queues %> <%= sidekiq_logfile ? ">> #{sidekiq_logfile} 2>&1" : nil %> &'" with timeout 30 seconds
+  stop program = "/bin/su - <%= sidekiq_user(role) %> -c 'ps -ax | grep "<%= "sidekiq .* #{fetch(:full_app_name)}" %>" | grep -v grep | awk "{print \$1}" | xargs --no-run-if-empty kill'" with timeout <%= fetch(:sidekiq_timeout).to_i + 10  %> seconds
   group <%= fetch(:sidekiq_monit_group) || fetch(:application) %>-sidekiq
-
-<% end %>


### PR DESCRIPTION
This update makes monit integration functional again. It has been broken since Sidekiq 6.0 was released with removed daemonization, pidfile and logfile options (mperham/sidekiq#4045)