### PR TITLE
Fix bug in switch_user and dry up common methods to a helpers module

### DIFF
--- a/lib/capistrano/sidekiq.rb
+++ b/lib/capistrano/sidekiq.rb
@@ -25,6 +25,7 @@ module Capistrano
   end
 end
 
+require_relative 'sidekiq/helpers'
 require_relative 'sidekiq/systemd'
 require_relative 'sidekiq/upstart'
 require_relative 'sidekiq/monit'

--- a/lib/capistrano/sidekiq/helpers.rb
+++ b/lib/capistrano/sidekiq/helpers.rb
@@ -1,0 +1,54 @@
+module Capistrano
+  module Sidekiq::Helpers
+    def sidekiq_require
+      if fetch(:sidekiq_require)
+        "--require #{fetch(:sidekiq_require)}"
+      end
+    end
+
+    def sidekiq_config
+      if fetch(:sidekiq_config)
+        "--config #{fetch(:sidekiq_config)}"
+      end
+    end
+
+    def sidekiq_concurrency
+      if fetch(:sidekiq_concurrency)
+        "--concurrency #{fetch(:sidekiq_concurrency)}"
+      end
+    end
+
+    def sidekiq_queues
+      Array(fetch(:sidekiq_queue)).map do |queue|
+        "--queue #{queue}"
+      end.join(' ')
+    end
+
+    def sidekiq_logfile
+      fetch(:sidekiq_log)
+    end
+
+    def switch_user(role)
+      su_user = sidekiq_user(role)
+      if su_user == role.user
+        yield
+      else
+        as su_user do
+          yield
+        end
+      end
+    end
+
+    def sidekiq_user(role = nil)
+      if role.nil?
+        fetch(:sidekiq_user)
+      else
+        properties = role.properties
+        properties.fetch(:sidekiq_user) || # local property for sidekiq only
+          fetch(:sidekiq_user) ||
+          properties.fetch(:run_as) || # global property across multiple capistrano gems
+          role.user
+      end
+    end
+  end
+end

--- a/lib/capistrano/sidekiq/monit.rb
+++ b/lib/capistrano/sidekiq/monit.rb
@@ -1,5 +1,7 @@
 module Capistrano
   class Sidekiq::Monit < Capistrano::Plugin
+    include Sidekiq::Helpers
+
     def set_defaults
       set_if_empty :monit_bin, '/usr/bin/monit'
       set_if_empty :sidekiq_monit_conf_dir, '/etc/monit/conf.d'

--- a/lib/capistrano/sidekiq/systemd.rb
+++ b/lib/capistrano/sidekiq/systemd.rb
@@ -1,5 +1,7 @@
 module Capistrano
   class Sidekiq::Systemd < Capistrano::Plugin
+    include Sidekiq::Helpers
+
     def set_defaults
       set_if_empty :sidekiq_service_unit_name, 'sidekiq'
       set_if_empty :sidekiq_service_unit_user, :user # :system

--- a/lib/capistrano/sidekiq/upstart.rb
+++ b/lib/capistrano/sidekiq/upstart.rb
@@ -1,5 +1,7 @@
 module Capistrano
   class Sidekiq::Upstart < Capistrano::Plugin
+    include Sidekiq::Helpers
+
     def set_defaults
       set_if_empty :sidekiq_service_unit_name, 'sidekiq'
     end

--- a/lib/capistrano/tasks/monit.rake
+++ b/lib/capistrano/tasks/monit.rake
@@ -87,57 +87,6 @@ namespace :sidekiq do
     fetch(:sidekiq_service_name, "sidekiq_#{fetch(:application)}_#{fetch(:sidekiq_env)}")
   end
 
-  def sidekiq_config
-    if fetch(:sidekiq_config)
-      "--config #{fetch(:sidekiq_config)}"
-    end
-  end
-
-  def sidekiq_concurrency
-    if fetch(:sidekiq_concurrency)
-      "--concurrency #{fetch(:sidekiq_concurrency)}"
-    end
-  end
-
-  def sidekiq_queues
-    Array(fetch(:sidekiq_queue)).map do |queue|
-      "--queue #{queue}"
-    end.join(' ')
-  end
-
-  def sidekiq_logfile
-    fetch(:sidekiq_log)
-  end
-
-  def sidekiq_require
-    if fetch(:sidekiq_require)
-      "--require #{fetch(:sidekiq_require)}"
-    end
-  end
-
-  def switch_user(role)
-    su_user = sidekiq_user(role)
-    if su_user == role.user
-      yield
-    else
-      backend.as su_user do
-        yield
-      end
-    end
-  end
-
-  def sidekiq_user(role = nil)
-    if role.nil?
-      fetch(:sidekiq_user)
-    else
-      properties = role.properties
-      properties.fetch(:sidekiq_user) ||
-        fetch(:sidekiq_user) ||
-        properties.fetch(:run_as) ||
-        role.user
-    end
-  end
-
   def sudo_if_needed(command)
     if use_sudo?
       backend.execute :sudo, command

--- a/lib/capistrano/tasks/monit.rake
+++ b/lib/capistrano/tasks/monit.rake
@@ -20,10 +20,10 @@ namespace :sidekiq do
       on roles(fetch(:sidekiq_roles)) do |role|
         @role = role
         git_plugin.upload_sidekiq_template 'sidekiq_monit', "#{fetch(:tmp_dir)}/monit.conf", @role
-  
+
         git_plugin.switch_user(role) do
           mv_command = "mv #{fetch(:tmp_dir)}/monit.conf #{fetch(:sidekiq_monit_conf_dir)}/#{fetch(:sidekiq_monit_conf_file)}"
-  
+
           git_plugin.sudo_if_needed mv_command
           git_plugin.sudo_if_needed "#{fetch(:monit_bin)} reload"
         end
@@ -117,7 +117,7 @@ namespace :sidekiq do
 
   def switch_user(role)
     su_user = sidekiq_user(role)
-    if su_user != role.user
+    if su_user == role.user
       yield
     else
       backend.as su_user do

--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -120,7 +120,7 @@ namespace :sidekiq do
 
   def switch_user(role)
     su_user = sidekiq_user
-    if su_user != role.user
+    if su_user == role.user
       yield
     else
       backend.as su_user do

--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -117,19 +117,4 @@ namespace :sidekiq do
       backend.execute :systemctl, "--user", "daemon-reload"
     end
   end
-
-  def switch_user(role)
-    su_user = sidekiq_user
-    if su_user == role.user
-      yield
-    else
-      backend.as su_user do
-        yield
-      end
-    end
-  end
-
-  def sidekiq_user
-    fetch(:sidekiq_user, fetch(:run_as))
-  end
 end

--- a/lib/capistrano/tasks/upstart.rake
+++ b/lib/capistrano/tasks/upstart.rake
@@ -98,49 +98,8 @@ namespace :sidekiq do
     end
   end
 
-  def switch_user(role)
-    su_user = sidekiq_user(role)
-    if su_user == role.user
-      yield
-    else
-      as su_user do
-        yield
-      end
-    end
-  end
-
-  def sidekiq_user(role = nil)
-    if role.nil?
-      fetch(:sidekiq_user)
-    else
-      properties = role.properties
-      properties.fetch(:sidekiq_user) || # local property for sidekiq only
-        fetch(:sidekiq_user) ||
-        properties.fetch(:run_as) || # global property across multiple capistrano gems
-        role.user
-    end
-  end
-
   def num_workers
     fetch(:sidekiq_upstart_num_workers, nil)
-  end
-
-  def sidekiq_config
-    if fetch(:sidekiq_config)
-      "--config #{fetch(:sidekiq_config)}"
-    end
-  end
-
-  def sidekiq_concurrency
-    if fetch(:sidekiq_concurrency)
-      "--concurrency #{fetch(:sidekiq_concurrency)}"
-    end
-  end
-
-  def sidekiq_queues
-    Array(fetch(:sidekiq_queue)).map do |queue|
-      "--queue #{queue}"
-    end.join(' ')
   end
 
 end


### PR DESCRIPTION
This PR fixes a bug in the `switch_user` function which would needlessly invoke `sudo` when the role user is the same as the `sidekiq` user. 

Furthermore, this PR also reduces code duplication (which was likely the source of the above bug).

Fixes #267.