### PR TITLE
Use File.join for systemd file path

### DIFF
--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -110,10 +110,10 @@ namespace :sidekiq do
         "/tmp/#{fetch :sidekiq_service_unit_name}.service"
     )
     if fetch(:sidekiq_service_unit_user) == :system
-      backend.execute :sudo, :mv, "/tmp/#{fetch :sidekiq_service_unit_name}.service", "#{systemd_path}/#{fetch :sidekiq_service_unit_name}.service"
+      backend.execute :sudo, :mv, "/tmp/#{fetch :sidekiq_service_unit_name}.service", File.join(systemd_path, "#{fetch :sidekiq_service_unit_name}.service")
       backend.execute :sudo, :systemctl, "daemon-reload"
     else
-      backend.execute :mv, "/tmp/#{fetch :sidekiq_service_unit_name}.service", "#{systemd_path}/#{fetch :sidekiq_service_unit_name}.service"
+      backend.execute :mv, "/tmp/#{fetch :sidekiq_service_unit_name}.service", File.join(systemd_path, "#{fetch :sidekiq_service_unit_name}.service")
       backend.execute :systemctl, "--user", "daemon-reload"
     end
   end


### PR DESCRIPTION
This line https://github.com/seuros/capistrano-sidekiq/blob/a4346067cd0af1124129cf27169edc98d4c015a0/lib/capistrano/tasks/systemd.rake#L82 has a trailing `/`, causing the `mv` destination path to be `/etc/systemd/system//sidekiq.service`.