### PR TITLE
Various systemd improvements - Multiple Process Support, Per Process Config, Proper Restarts with timeout and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ And then execute:
     require 'capistrano/sidekiq'
     install_plugin Capistrano::Sidekiq  # Default sidekiq tasks
     # Then select your service manager
-    install_plugin Capistrano::Sidekiq::Systemd 
-    # or  
+    install_plugin Capistrano::Sidekiq::Systemd
+    # or
     install_plugin Capistrano::Sidekiq::Upstart  # tests needed
-    # or  
+    # or
     install_plugin Capistrano::Sidekiq::Monit  # tests needed
 ```
 
@@ -36,6 +36,10 @@ Configurable options, shown here with defaults:
 :sidekiq_pid => File.join(shared_path, 'tmp', 'pids', 'sidekiq.pid') # ensure this path exists in production before deploying.
 :sidekiq_env => fetch(:rack_env, fetch(:rails_env, fetch(:stage)))
 :sidekiq_log => File.join(shared_path, 'log', 'sidekiq.log')
+:sidekiq_config => 'config/sidekiq.yml'
+:sidekiq_concurrency => 25
+:sidekiq_queues => %w(default high low)
+:sidekiq_processes => 1 # number of systemd processes you want to start
 
 # sidekiq systemd options
 :sidekiq_service_templates_path => 'config/deploy/templates' # to be used if a custom template is needed (filaname should be #{fetch(:sidekiq_service_unit_name)}.service.capistrano.erb or sidekiq.service.capistrano.erb
@@ -51,10 +55,11 @@ Configurable options, shown here with defaults:
 :monit_bin => '/usr/bin/monit'
 :sidekiq_monit_default_hooks => true
 :sidekiq_monit_group => nil
-:sidekiq_service_name => "sidekiq_#{fetch(:application)}" 
+:sidekiq_service_name => "sidekiq_#{fetch(:application)}"
 
 :sidekiq_user => nil #user to run sidekiq as
 ```
+See `capistrano/sidekiq/helpers.rb` for other undocumented configuration settings.
 
 ## Known issues with Capistrano 3
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Configurable options, shown here with defaults:
 :sidekiq_log => File.join(shared_path, 'log', 'sidekiq.log')
 
 # sidekiq systemd options
+:sidekiq_service_templates_path => 'config/deploy/templates' # to be used if a custom template is needed (filaname should be #{fetch(:sidekiq_service_unit_name)}.service.capistrano.erb or sidekiq.service.capistrano.erb
 :sidekiq_service_unit_name => 'sidekiq'
 :sidekiq_service_unit_user => :user # :system
 :sidekiq_enable_lingering => true

--- a/README.md
+++ b/README.md
@@ -36,7 +36,13 @@ Configurable options, shown here with defaults:
 :sidekiq_pid => File.join(shared_path, 'tmp', 'pids', 'sidekiq.pid') # ensure this path exists in production before deploying.
 :sidekiq_env => fetch(:rack_env, fetch(:rails_env, fetch(:stage)))
 :sidekiq_log => File.join(shared_path, 'log', 'sidekiq.log')
+# single config
 :sidekiq_config => 'config/sidekiq.yml'
+# per process config - process 1, process 2,... etc.
+:sidekiq_config => [
+    'config/sidekiq_config1.yml',
+    'config/sidekiq_config2.yml'
+]
 :sidekiq_concurrency => 25
 :sidekiq_queues => %w(default high low)
 :sidekiq_processes => 1 # number of systemd processes you want to start

--- a/lib/capistrano/sidekiq/helpers.rb
+++ b/lib/capistrano/sidekiq/helpers.rb
@@ -1,5 +1,6 @@
 module Capistrano
   module Sidekiq::Helpers
+
     def sidekiq_require
       if fetch(:sidekiq_require)
         "--require #{fetch(:sidekiq_require)}"
@@ -50,5 +51,6 @@ module Capistrano
           role.user
       end
     end
+
   end
 end

--- a/lib/capistrano/sidekiq/systemd.rb
+++ b/lib/capistrano/sidekiq/systemd.rb
@@ -7,6 +7,7 @@ module Capistrano
       set_if_empty :sidekiq_service_unit_user, :user # :system
       set_if_empty :sidekiq_enable_lingering, true
       set_if_empty :sidekiq_lingering_user, nil
+      set_if_empty :sidekiq_service_templates_path, 'config/deploy/templates'
     end
 
     def define_tasks

--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -11,10 +11,4 @@ namespace :sidekiq do
     after 'deploy:published', 'sidekiq:start'
     after 'deploy:failed', 'sidekiq:restart'
   end
-
-  desc 'Restart sidekiq'
-  task :restart do
-    invoke! 'sidekiq:stop'
-    invoke! 'sidekiq:start'
-  end
 end

--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -120,4 +120,37 @@ namespace :sidekiq do
       backend.execute :systemctl, "--user", "daemon-reload"
     end
   end
+
+  def switch_user(role)
+    su_user = sidekiq_user
+    if su_user != role.user
+      yield
+    else
+      backend.as su_user do
+        yield
+      end
+    end
+  end
+
+  def sidekiq_user
+    fetch(:sidekiq_user, fetch(:run_as))
+  end
+
+  def sidekiq_config
+    if fetch(:sidekiq_config)
+      "--config #{fetch(:sidekiq_config)}"
+    end
+  end
+
+  def sidekiq_concurrency
+    if fetch(:sidekiq_concurrency)
+      "--concurrency #{fetch(:sidekiq_concurrency)}"
+    end
+  end
+
+  def sidekiq_queues
+    Array(fetch(:sidekiq_queue)).map do |queue|
+      "--queue #{queue}"
+    end.join(' ')
+  end
 end

--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -23,34 +23,42 @@ namespace :sidekiq do
     on roles fetch(:sidekiq_roles) do |role|
       git_plugin.switch_user(role) do
         git_plugin.quiet_sidekiq
-        start_time = Time.now
-        running = nil
+        git_plugin.process_block do |process|
+          start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          running = nil
 
-        # get running workers
-        while (running.nil? || running > 0) && start_time > 30.seconds.ago do
-          command_args =
+          # get running workers
+          while (running.nil? || running > 0) && git_plugin.duration(start_time) < 30 do
+            command_args =
             if fetch(:sidekiq_service_unit_user) == :system
-              [:sudo, :systemctl]
+              [:sudo, 'systemd-cgls']
             else
-              [:systemctl, "--user"]
+              ['systemd-clgs', '--user']
             end
-          command_args.push(:status, git_plugin.sidekiq_service_unit_name)
-          status = capture(*command_args, raise_on_non_zero_exit: false)
-          status_match = status.match(/\[(?<running>\d+) of (?<total>\d+) busy\]/)
-          next unless status_match
+            # need to pipe through tr -cd... to strip out systemd colors or you
+            # get log error messages for non UTF-8 characters.
+            command_args.push(
+              '-u', "#{git_plugin.sidekiq_service_unit_name(process: process)}.service",
+              '|', 'tr -cd \'\11\12\15\40-\176\''
+            )
+            status = capture(*command_args, raise_on_non_zero_exit: false)
+            status_match = status.match(/\[(?<running>\d+) of (?<total>\d+) busy\]/)
+            break unless status_match
 
-          running = status_match[:running]&.to_i
+            running = status_match[:running]&.to_i
 
-          colors = SSHKit::Color.new($stdout)
-          if running.zero?
-            puts colors.colorize('    ✔ No running workers. Shutting down for restart!', :green)
-          else
-            puts colors.colorize("    ⧗ Waiting for #{running} workers.", :yellow)
+            colors = SSHKit::Color.new($stdout)
+            if running.zero?
+              info colors.colorize("✔ Process ##{process}: No running workers. Shutting down for restart!", :green)
+            else
+              info colors.colorize("⧗ Process ##{process}: Waiting for #{running} workers.", :yellow)
+              sleep(1)
+            end
           end
-        end
 
-        git_plugin.systemctl_command(:stop)
-        git_plugin.systemctl_command(:start)
+          git_plugin.systemctl_command(:stop, process: process)
+          git_plugin.systemctl_command(:start, process: process)
+        end
       end
     end
   end
@@ -69,6 +77,11 @@ namespace :sidekiq do
     on roles fetch(:sidekiq_roles) do |role|
       git_plugin.switch_user(role) do
         git_plugin.create_systemd_template
+        if git_plugin.config_per_process?
+          git_plugin.process_block do |process|
+            git_plugin.create_systemd_config_symlink(process)
+          end
+        end
         git_plugin.systemctl_command(:enable)
 
         if fetch(:sidekiq_service_unit_user) != :system && fetch(:sidekiq_enable_lingering)
@@ -84,6 +97,11 @@ namespace :sidekiq do
       git_plugin.switch_user(role) do
         git_plugin.systemctl_command(:stop)
         git_plugin.systemctl_command(:disable)
+        if git_plugin.config_per_process?
+          git_plugin.process_block do |process|
+            git_plugin.delete_systemd_config_symlink(process)
+          end
+        end
         execute :sudo, :rm, '-f', File.join(
           fetch(:service_unit_path, git_plugin.fetch_systemd_unit_path),
           git_plugin.sidekiq_service_file_name
@@ -144,15 +162,55 @@ namespace :sidekiq do
     end
   end
 
-  def systemctl_command(*args)
+  def create_systemd_config_symlink(process)
+    config = fetch(:sidekiq_config)
+    return unless config
+
+    process_config = config[process - 1]
+    unless process_config.present?
+      backend.error(
+        "No configuration for Process ##{process} found. "\
+        'Please make sure you have 1 item in :sidekiq_config for each process.'
+      )
+      exit 1
+    end
+
+    base_path = fetch(:deploy_to)
+    config_link_base_path = File.join(base_path, 'shared', 'sidekiq_systemd')
+    config_link_path = File.join(
+      config_link_base_path, sidekiq_systemd_config_name(process)
+    )
+    process_config_path = File.join(base_path, 'current', process_config)
+
+    backend.execute :mkdir, '-p', config_link_base_path
+    backend.execute :ln, '-sf', process_config_path, config_link_path
+  end
+
+  def delete_systemd_config_symlink(process)
+    config_link_path = File.join(
+      fetch(:deploy_to),  'shared', 'sidekiq_systemd',
+      sidekiq_systemd_config_name(process)
+    )
+    backend.execute :rm, config_link_path, raise_on_non_zero_exit: false
+  end
+
+  def systemctl_command(*args, process: nil)
     execute_array =
       if fetch(:sidekiq_service_unit_user) == :system
         [:sudo, :systemctl]
       else
         [:systemctl, '--user']
       end
-    execute_array.push(*args, sidekiq_service_unit_name).flatten
-    backend.execute(*execute_array, raise_on_non_zero_exit: false)
+
+    if process.present?
+      execute_array.push(
+        *args, sidekiq_service_unit_name(process: process)
+        ).flatten
+      backend.execute(*execute_array, raise_on_non_zero_exit: false)
+    else
+      execute_array.push(*args, sidekiq_service_unit_name).flatten
+      backend.execute(*execute_array, raise_on_non_zero_exit: false)
+    end
   end
 
   def quiet_sidekiq
@@ -175,8 +233,17 @@ namespace :sidekiq do
   end
 
   def sidekiq_config
-    if fetch(:sidekiq_config)
-      "--config #{fetch(:sidekiq_config)}"
+    config = fetch(:sidekiq_config)
+    return unless config
+
+    if config_per_process?
+      config = File.join(
+        fetch(:deploy_to), 'shared', 'sidekiq_systemd',
+        sidekiq_systemd_config_name
+      )
+      "--config #{config}"
+    else
+      "--config #{config}"
     end
   end
 
@@ -197,11 +264,37 @@ namespace :sidekiq do
   end
 
   def sidekiq_service_file_name
-    "#{fetch :sidekiq_service_unit_name}@.service"
+    "#{fetch(:sidekiq_service_unit_name)}@.service"
   end
 
-  def sidekiq_service_unit_name
-    "#{fetch(:sidekiq_service_unit_name)}@{1..#{sidekiq_processes}}"
+  def sidekiq_service_unit_name(process: nil)
+    if process.present?
+      "#{fetch(:sidekiq_service_unit_name)}@#{process}"
+    else
+      "#{fetch(:sidekiq_service_unit_name)}@{1..#{sidekiq_processes}}"
+    end
+  end
+
+  # process = 1 | sidekiq_systemd_1.yaml
+  # process = nil | sidekiq_systemd_%i.yaml
+  def sidekiq_systemd_config_name(process = nil)
+    file_name = 'sidekiq_systemd_'
+    file_name << (process.present? ? process.to_s : '%i')
+    "#{file_name}.yaml"
+  end
+
+  def config_per_process?
+    fetch(:sidekiq_config).is_a?(Array)
+  end
+
+  def process_block
+    (1..sidekiq_processes).each do |process|
+      yield(process)
+    end
+  end
+
+  def duration(start_time)
+    Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
   end
 
 end

--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -3,34 +3,63 @@ git_plugin = self
 namespace :sidekiq do
 
   standard_actions = {
-    start: 'Start sidekiq',
-    stop: 'Stop sidekiq (graceful shutdown within timeout, put unfinished tasks back to Redis)',
-    status: 'Sidekiq status'
+    start: 'Start Sidekiq',
+    stop: 'Stop Sidekiq (graceful shutdown within timeout, put unfinished tasks back to Redis)',
+    status: 'Get Sidekiq Status'
   }
-  standard_actions.each do |action, description|
+  standard_actions.each do |command, description|
     desc description
-    task action do
+    task command do
       on roles fetch(:sidekiq_roles) do |role|
         git_plugin.switch_user(role) do
-          if fetch(:sidekiq_service_unit_user) == :system
-            execute :sudo, :systemctl, action, git_plugin.sidekiq_service_unit_name
-          else
-            execute :systemctl, '--user', action, git_plugin.sidekiq_service_unit_name
-          end
+          git_plugin.systemctl_command(command)
         end
       end
     end
   end
 
-  desc 'Quiet sidekiq (stop fetching new tasks from Redis)'
+  desc 'Restart Sidekiq (Quiet, Wait till workers finish or 30 seconds, Stop, Start)'
+  task :restart do
+    on roles fetch(:sidekiq_roles) do |role|
+      git_plugin.switch_user(role) do
+        git_plugin.quiet_sidekiq
+        start_time = Time.now
+        running = nil
+
+        # get running workers
+        while (running.nil? || running > 0) && start_time > 30.seconds.ago do
+          command_args =
+            if fetch(:sidekiq_service_unit_user) == :system
+              [:sudo, :systemctl]
+            else
+              [:systemctl, "--user"]
+            end
+          command_args.push(:status, git_plugin.sidekiq_service_unit_name)
+          status = capture(*command_args, raise_on_non_zero_exit: false)
+          status_match = status.match(/\[(?<running>\d+) of (?<total>\d+) busy\]/)
+          next unless status_match
+
+          running = status_match[:running]&.to_i
+
+          colors = SSHKit::Color.new($stdout)
+          if running.zero?
+            puts colors.colorize('    ✔ No running workers. Shutting down for restart!', :green)
+          else
+            puts colors.colorize("    ⧗ Waiting for #{running} workers.", :yellow)
+          end
+        end
+
+        git_plugin.systemctl_command(:stop)
+        git_plugin.systemctl_command(:start)
+      end
+    end
+  end
+
+  desc 'Quiet Sidekiq (stop fetching new tasks from Redis)'
   task :quiet do
     on roles fetch(:sidekiq_roles) do |role|
       git_plugin.switch_user(role) do
-        if fetch(:sidekiq_service_unit_user) == :system
-          execute :sudo, :systemctl, "reload", git_plugin.sidekiq_service_unit_name, raise_on_non_zero_exit: false
-        else
-          execute :systemctl, "--user", "reload", git_plugin.sidekiq_service_unit_name, raise_on_non_zero_exit: false
-        end
+        git_plugin.quiet_sidekiq
       end
     end
   end
@@ -40,26 +69,25 @@ namespace :sidekiq do
     on roles fetch(:sidekiq_roles) do |role|
       git_plugin.switch_user(role) do
         git_plugin.create_systemd_template
-        if fetch(:sidekiq_service_unit_user) == :system
-          execute :sudo, :systemctl, :enable, git_plugin.sidekiq_service_unit_name
-        else
-          execute :systemctl, "--user", :enable, git_plugin.sidekiq_service_unit_name
-          execute :loginctl, "enable-linger", fetch(:sidekiq_lingering_user) if fetch(:sidekiq_enable_lingering)
+        git_plugin.systemctl_command(:enable)
+
+        if fetch(:sidekiq_service_unit_user) != :system && fetch(:sidekiq_enable_lingering)
+          execute :loginctl, "enable-linger", fetch(:sidekiq_lingering_user)
         end
       end
     end
   end
 
-  desc 'UnInstall systemd sidekiq service'
+  desc 'Uninstall systemd sidekiq service'
   task :uninstall do
     on roles fetch(:sidekiq_roles) do |role|
       git_plugin.switch_user(role) do
-        if fetch(:sidekiq_service_unit_user) == :system
-          execute :sudo, :systemctl, "disable", git_plugin.sidekiq_service_unit_name
-        else
-          execute :systemctl, "--user", "disable", git_plugin.sidekiq_service_unit_name
-        end
-        execute :sudo, :rm, '-f', File.join(fetch(:service_unit_path, git_plugin.fetch_systemd_unit_path), git_plugin.sidekiq_service_file_name)
+        git_plugin.systemctl_command(:stop)
+        git_plugin.systemctl_command(:disable)
+        execute :sudo, :rm, '-f', File.join(
+          fetch(:service_unit_path, git_plugin.fetch_systemd_unit_path),
+          git_plugin.sidekiq_service_file_name
+        )
       end
     end
   end
@@ -114,6 +142,21 @@ namespace :sidekiq do
       backend.execute :mv, temp_file_name, systemd_file_name
       backend.execute :systemctl, "--user", "daemon-reload"
     end
+  end
+
+  def systemctl_command(*args)
+    execute_array =
+      if fetch(:sidekiq_service_unit_user) == :system
+        [:sudo, :systemctl]
+      else
+        [:systemctl, '--user']
+      end
+    execute_array.push(*args, sidekiq_service_unit_name).flatten
+    backend.execute(*execute_array, raise_on_non_zero_exit: false)
+  end
+
+  def quiet_sidekiq
+    systemctl_command(:kill, '-s', :TSTP)
   end
 
   def switch_user(role)

--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -87,7 +87,10 @@ namespace :sidekiq do
   end
 
   def compiled_template
+    local_template_directory = fetch(:sidekiq_service_templates_path)
     search_paths = [
+      File.join(local_template_directory, "#{fetch(:sidekiq_service_unit_name)}.service.capistrano.erb"),
+      File.join(local_template_directory, 'sidekiq.service.capistrano.erb'),
       File.expand_path(
           File.join(*%w[.. .. .. generators capistrano sidekiq systemd templates sidekiq.service.capistrano.erb]),
           __FILE__

--- a/lib/generators/capistrano/sidekiq/systemd/templates/sidekiq.service.capistrano.erb
+++ b/lib/generators/capistrano/sidekiq/systemd/templates/sidekiq.service.capistrano.erb
@@ -5,7 +5,7 @@ After=syslog.target network.target
 [Service]
 Type=simple
 WorkingDirectory=<%= File.join(fetch(:deploy_to), 'current') %>
-ExecStart=<%= SSHKit.config.command_map[:bundle] %> exec sidekiq -e <%= fetch(:sidekiq_env) %>
+ExecStart=<%= SSHKit.config.command_map[:bundle] %> exec sidekiq -e <%= fetch(:sidekiq_env) %> <%= sidekiq_config %> <%= sidekiq_concurrency %> <%= sidekiq_queues %>
 ExecReload=/bin/kill -TSTP $MAINPID
 ExecStop=/bin/kill -TERM $MAINPID
 <%="StandardOutput=append:#{fetch(:sidekiq_log)}" if fetch(:sidekiq_log) %>

--- a/lib/generators/capistrano/sidekiq/systemd/templates/sidekiq.service.capistrano.erb
+++ b/lib/generators/capistrano/sidekiq/systemd/templates/sidekiq.service.capistrano.erb
@@ -1,26 +1,70 @@
+# Source: https://github.com/mperham/sidekiq/blob/master/examples/systemd/sidekiq.service
+#
+# This file tells systemd how to run Sidekiq as a 24/7 long-running daemon.
+#
+# Customize this file based on your bundler location, app directory, etc.
+# Customize and copy this into /usr/lib/systemd/system (CentOS) or /lib/systemd/system (Ubuntu).
+# Then run:
+#   - systemctl enable sidekiq
+#   - systemctl {start,stop,restart} sidekiq
+#
+# This file corresponds to a single Sidekiq process.  Add multiple copies
+# to run multiple processes (sidekiq-1, sidekiq-2, etc).
+#
+# Use `journalctl -u sidekiq -rn 100` to view the last 100 lines of log output.
+#
 [Unit]
 Description=sidekiq for <%= "#{fetch(:application)} (#{fetch(:stage)})" %>
+# start us only once the network and logging subsystems are available,
+# consider adding redis-server.service if Redis is local and systemd-managed.
 After=syslog.target network.target
 
+# See these pages for lots of options:
+#
+#   https://www.freedesktop.org/software/systemd/man/systemd.service.html
+#   https://www.freedesktop.org/software/systemd/man/systemd.exec.html
+#
+# THOSE PAGES ARE CRITICAL FOR ANY LINUX DEVOPS WORK; read them multiple
+# times! systemd is a critical tool for all developers to know and understand.
+#
 [Service]
-Type=simple
+#
+#      !!!!  !!!!  !!!!
+#
+# As of v6.0.6, Sidekiq automatically supports systemd's `Type=notify` and watchdog service
+# monitoring. If you are using an earlier version of Sidekiq, change this to `Type=simple`
+# and remove the `WatchdogSec` line.
+#
+#      !!!!  !!!!  !!!!
+#
+Type=notify
+# If your Sidekiq process locks up, systemd's watchdog will restart it within seconds.
+WatchdogSec=10
+
 WorkingDirectory=<%= File.join(fetch(:deploy_to), 'current') %>
 ExecStart=<%= SSHKit.config.command_map[:bundle] %> exec sidekiq -e <%= fetch(:sidekiq_env) %> <%= sidekiq_config %> <%= sidekiq_concurrency %> <%= sidekiq_queues %>
-ExecReload=/bin/kill -TSTP $MAINPID
-ExecStop=/bin/kill -TERM $MAINPID
-<%="StandardOutput=append:#{fetch(:sidekiq_log)}" if fetch(:sidekiq_log) %>
-<%="StandardError=append:#{fetch(:sidekiq_error_log)}" if fetch(:sidekiq_error_log) %>
+
+# Use `systemctl kill -s TSTP sidekiq` to quiet the Sidekiq process
+
 <%="User=#{sidekiq_user}" if sidekiq_user %>
-<%="EnvironmentFile=#{fetch(:sidekiq_service_unit_env_file)}" if fetch(:sidekiq_service_unit_env_file) %>
+UMask=0002
 
-<% fetch(:sidekiq_service_unit_env_vars, []).each do |environment_variable| %>
-  <%="Environment=#{environment_variable}" %>
-<% end %>
+<%="EnvironmentFile=#{File.join(fetch(:deploy_to), 'current')}/#{fetch(:sidekiq_service_unit_env_file)}" if fetch(:sidekiq_service_unit_env_file) %>
 
+# Greatly reduce Ruby memory fragmentation and heap usage
+# https://www.mikeperham.com/2018/04/25/taming-rails-memory-bloat/
+Environment=MALLOC_ARENA_MAX=2
+
+# if we crash, restart
 RestartSec=1
 Restart=on-failure
 
+# output goes to /var/log/syslog (Ubuntu) or /var/log/messages (CentOS)
+<%="StandardOutput=append:#{fetch(:sidekiq_log)}" if fetch(:sidekiq_log) %>
+<%="StandardError=append:#{fetch(:sidekiq_error_log)}" if fetch(:sidekiq_error_log) %>
+
+# This will default to "bundler" if we don't specify it
 SyslogIdentifier=sidekiq
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target


### PR DESCRIPTION
I've tried to cleanup the overall systemd support in this repository. I've merged in a few other contributors PRs (#262 and #265) since they both were of use to me at some point.

Here are the major changes

- Tried to refactor and cleanup the tasks for managing systemd as a whole.
- Support for multiple Sidekiq processes via `set :sidekiq_processes, 3` which was previously removed I guess. This uses systemd's built in functionality to support multiple processes. The service file gets named `sidekiq@.service` and then processes are managed using `systemctl [command] sidekiq@{1..2}`.
- Updated the systemd template using the [official example](https://github.com/mperham/sidekiq/blob/master/examples/systemd/sidekiq.service).
- Proper Restart Task
   - Runs Quiet (`systemctl kill -s TSTP sidekiq@{1..2}`)
   - Polls status until running workers is 0 or 30 seconds has passed 
   - Runs Stop
   - Runs Start. 