### PR TITLE
README: Add section about older Systemd versions logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ If your deploy user has no need in `sudo` for using monit, you can disable it as
 set :sidekiq_monit_use_sudo, false
 ```
 
+## Configuring the log files on systems with less recent Systemd versions
+
+The template used by this project assumes a recent version of Systemd (v240+, e.g. Ubuntu 20.04).
+
+On systems with a less recent version, the `append:` functionality is not supported, and the Sidekiq log messages are sent to the syslog.
+
+It's possible to workaround this limitation by configuring the system logger to filter the Sidekiq messages; see [wiki](/../../wiki/Configuring-append-mode-log-files-via-Syslog-NG).
+
 ## Contributing
 
 1. Fork it


### PR DESCRIPTION
Explain what happens to Sidekiq log messages when installing on systems with a System version older than v240.

Closes #283.