### PR TITLE
Fixed sidekiq.service autostart in --user mode

### DIFF
--- a/lib/generators/capistrano/sidekiq/systemd/templates/sidekiq.service.capistrano.erb
+++ b/lib/generators/capistrano/sidekiq/systemd/templates/sidekiq.service.capistrano.erb
@@ -67,4 +67,4 @@ Restart=on-failure
 SyslogIdentifier=sidekiq
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target


### PR DESCRIPTION
Based on this comment https://github.com/systemd/systemd/issues/2690#issuecomment-186973730 `WantedBy` should be `default.target` for `--user` mode to let service start on system boot.
