### PR TITLE
added sidekiq_service_templates_path to manage custom systemd templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Configurable options, shown here with defaults:
 :sidekiq_log => File.join(shared_path, 'log', 'sidekiq.log')
 
 # sidekiq systemd options
+:sidekiq_service_templates_path => 'config/deploy/templates' # to be used if a custom template is needed (filaname should be #{fetch(:sidekiq_service_unit_name)}.service.capistrano.erb or sidekiq.service.capistrano.erb
 :sidekiq_service_unit_name => 'sidekiq'
 :sidekiq_service_unit_user => :user # :system
 :sidekiq_enable_lingering => true

--- a/lib/capistrano/sidekiq/systemd.rb
+++ b/lib/capistrano/sidekiq/systemd.rb
@@ -5,6 +5,7 @@ module Capistrano
       set_if_empty :sidekiq_service_unit_user, :user # :system
       set_if_empty :sidekiq_enable_lingering, true
       set_if_empty :sidekiq_lingering_user, nil
+      set_if_empty :sidekiq_service_templates_path, 'config/deploy/templates'
     end
 
     def define_tasks

--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -87,7 +87,10 @@ namespace :sidekiq do
   end
 
   def compiled_template
+    local_template_directory = fetch(:sidekiq_service_templates_path)
     search_paths = [
+      File.join(local_template_directory, "#{fetch(:sidekiq_service_unit_name)}.service.capistrano.erb"),
+      File.join(local_template_directory, 'sidekiq.service.capistrano.erb'),
       File.expand_path(
           File.join(*%w[.. .. .. generators capistrano sidekiq systemd templates sidekiq.service.capistrano.erb]),
           __FILE__


### PR DESCRIPTION
The main community repository at https://github.com/seuros/capistrano-sidekiq supports custom template path in master, however it has not been released to a stable version yet. 

This will tie us over until a stable version has been released with what we need. 

Commit hash from: https://github.com/seuros/capistrano-sidekiq/commit/4fd530f43067feccc6015787cf7643b039564bfb 