### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ And then execute:
 ```
 
 
-Configurable options, shown here with defaults:
+Configurable options - Please ensure you check your version's branch for the available settings - shown here with defaults:
 
 ```ruby
 :sidekiq_roles => :app
@@ -44,7 +44,7 @@ Configurable options, shown here with defaults:
     'config/sidekiq_config2.yml'
 ]
 :sidekiq_concurrency => 25
-:sidekiq_queues => %w(default high low)
+:sidekiq_queue => %w(default high low)
 :sidekiq_processes => 1 # number of systemd processes you want to start
 
 # sidekiq systemd options


### PR DESCRIPTION
The 's' in the word queues is not expected by the fetch in the systemd helper which breaks the template creation: 
```Array(fetch(:sidekiq_queue)).map do |queue|```

Added a disclaimer that the options listed are for the master branch as I made a mistake and did not realize that the systemd template file is not configurable unless you are on master