### PR TITLE
fix: monit config template

### DIFF
--- a/lib/generators/capistrano/sidekiq/monit/templates/sidekiq_monit.conf.erb
+++ b/lib/generators/capistrano/sidekiq/monit/templates/sidekiq_monit.conf.erb
@@ -1,6 +1,8 @@
-# Monit configuration for Sidekiq :  <%= fetch(:application) %>
-  check process <%= sidekiq_service_name %>
-  matching 'sidekiq .* <%= fetch(:full_app_name) %>'
-  start program = "/bin/su - <%= sidekiq_user(role) %> -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:bundle] %> exec sidekiq -e <%= fetch(:sidekiq_env) %> <%= sidekiq_config %> <%= sidekiq_concurrency %> <%= sidekiq_require %> <%= sidekiq_queues %> <%= sidekiq_logfile ? ">> #{sidekiq_logfile} 2>&1" : nil %> &'" with timeout 30 seconds
-  stop program = "/bin/su - <%= sidekiq_user(role) %> -c 'ps -ax | grep "<%= "sidekiq .* #{fetch(:full_app_name)}" %>" | grep -v grep | awk "{print \$1}" | xargs --no-run-if-empty kill'" with timeout <%= fetch(:sidekiq_timeout).to_i + 10  %> seconds
+# Monit configuration for Sidekiq
+# Service name: <%= sidekiq_service_name %>
+#
+check process <%= sidekiq_service_name %>
+  matching 'sidekiq .* <%= fetch(:application) %>'
+  start program = "/bin/su - <%= sidekiq_user(role) %> -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:bundle] %> exec sidekiq -e <%= fetch(:sidekiq_env) %> <%= sidekiq_config %> <%= sidekiq_concurrency %> <%= sidekiq_require %> <%= sidekiq_queues %> <%= sidekiq_logfile ? ">> #{sidekiq_logfile} 2>&1" : nil %> &'" with timeout <%= fetch(:sidekiq_timeout).to_i + 10 %> seconds
+  stop program = "/bin/su - <%= sidekiq_user(role) %> -c 'ps ax | grep "<%= "sidekiq .* #{fetch(:application)}" %>" | grep -v grep | awk "{print \$1}" | xargs --no-run-if-empty kill'" with timeout <%= fetch(:sidekiq_timeout).to_i + 10  %> seconds
   group <%= fetch(:sidekiq_monit_group) || fetch(:application) %>-sidekiq


### PR DESCRIPTION
The config template had a couple issues that made it not work.
- The `check process` line was indented when it should not have been.
- The use of `fetch(:full_app_name)` instead of `fetch(:application)`. No idea where `:full_app_name` was supposed to come from, but, at least for me, it doesn't exist.
- The use of `ps -ax` instead of `ps ax`. The former would produce a warning because `ps -aux` is distinct from `ps aux`.

Also, formatted the comment to match the puma plugin's template for consistency.