### PR TITLE
Fix #253: $HOME is unexpanded in service unit file

### DIFF
--- a/lib/capistrano/sidekiq/helpers.rb
+++ b/lib/capistrano/sidekiq/helpers.rb
@@ -52,5 +52,9 @@ module Capistrano
       end
     end
 
+    def expanded_bundle_path
+      backend.capture(:echo, SSHKit.config.command_map[:bundle]).strip
+    end
+
   end
 end

--- a/lib/generators/capistrano/sidekiq/systemd/templates/sidekiq.service.capistrano.erb
+++ b/lib/generators/capistrano/sidekiq/systemd/templates/sidekiq.service.capistrano.erb
@@ -42,7 +42,7 @@ Type=notify
 WatchdogSec=10
 
 WorkingDirectory=<%= File.join(fetch(:deploy_to), 'current') %>
-ExecStart=<%= SSHKit.config.command_map[:bundle] %> exec sidekiq -e <%= fetch(:sidekiq_env) %> <%= sidekiq_config %> <%= sidekiq_concurrency %> <%= sidekiq_queues %>
+ExecStart=<%= expanded_bundle_path %> exec sidekiq -e <%= fetch(:sidekiq_env) %> <%= sidekiq_config %> <%= sidekiq_concurrency %> <%= sidekiq_queues %>
 
 # Use `systemctl kill -s TSTP sidekiq` to quiet the Sidekiq process
 


### PR DESCRIPTION
Expands $HOME before writing it to the template file.
Fix taken from seuros/capistrano-puma https://github.com/seuros/capistrano-puma/search?q=expanded_bundle_command