### PR TITLE
restore sidekiq unit env vars

### DIFF
--- a/lib/generators/capistrano/sidekiq/systemd/templates/sidekiq.service.capistrano.erb
+++ b/lib/generators/capistrano/sidekiq/systemd/templates/sidekiq.service.capistrano.erb
@@ -51,9 +51,9 @@ UMask=0002
 
 <%="EnvironmentFile=#{File.join(fetch(:deploy_to), 'current')}/#{fetch(:sidekiq_service_unit_env_file)}" if fetch(:sidekiq_service_unit_env_file) %>
 
-# Greatly reduce Ruby memory fragmentation and heap usage
-# https://www.mikeperham.com/2018/04/25/taming-rails-memory-bloat/
-Environment=MALLOC_ARENA_MAX=2
+<% fetch(:sidekiq_service_unit_env_vars, []).each do |environment_variable| %>
+  <%="Environment=#{environment_variable}" %>
+<% end %>
 
 # if we crash, restart
 RestartSec=1


### PR DESCRIPTION
This PR restoring sidekiq_unit_env_vars option.

If memory usage wants reduce,  that better define on unit_env_vars.
Please review it.
Regards.
