### PR TITLE
Support multiple processes in `sidekiq:install`

### DIFF
--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -151,7 +151,15 @@ namespace :sidekiq do
     backend.execute :mkdir, '-p', systemd_path if fetch(:sidekiq_service_unit_user) == :user
 
     temp_file_name = File.join('/tmp', sidekiq_service_file_name)
-    backend.upload!(StringIO.new(ctemplate), temp_file_name)
+    if sidekiq_processes > 1
+      for 1..sidekiq_processes do |index|
+        temp_file_name = File.join('/tmp', sidekiq_service_file_name(index))
+        backend.upload!(StringIO.new(ctemplate), temp_file_name)
+      end
+
+    else
+      backend.upload!(StringIO.new(ctemplate), temp_file_name)
+    end
     if fetch(:sidekiq_service_unit_user) == :system
       backend.execute :sudo, :mv, temp_file_name, systemd_file_name
       backend.execute :sudo, :systemctl, 'daemon-reload'
@@ -255,8 +263,9 @@ namespace :sidekiq do
     end.join(' ')
   end
 
-  def sidekiq_service_file_name
-    "#{fetch(:sidekiq_service_unit_name)}.service"
+  def sidekiq_service_file_name(index = nil)
+    return "#{fetch(:sidekiq_service_unit_name)}.service" unless index
+    "#{fetch(:sidekiq_service_unit_name)}@#{index}.service"
   end
 
   def sidekiq_service_unit_name(process: nil)

--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -146,18 +146,16 @@ namespace :sidekiq do
   def create_systemd_template
     ctemplate = compiled_template
     systemd_path = fetch(:service_unit_path, fetch_systemd_unit_path)
-    systemd_file_name = File.join(systemd_path, sidekiq_service_file_name)
-
     backend.execute :mkdir, '-p', systemd_path if fetch(:sidekiq_service_unit_user) == :user
-
 
     if sidekiq_processes > 1
       range = 1..sidekiq_processes
     else
       range = 0..0
     end
-    for range do |index|
+    range.each do |index|
       temp_file_name = File.join('/tmp', sidekiq_service_file_name(index))
+      systemd_file_name = File.join(systemd_path, sidekiq_service_file_name(index))
       backend.upload!(StringIO.new(ctemplate), temp_file_name)
 
       if fetch(:sidekiq_service_unit_user) == :system


### PR DESCRIPTION
This updates the uploading of systemd service files for multiple process sidekiq workers. It does not break existing codebases by implementing a naming structure like `sidekiq@1.service` where only a single process is requested.

Connects to https://github.com/seuros/capistrano-sidekiq/issues/298