### PR TITLE
Fix multi-process support for stop, start, status, and quiet tasks

### DIFF
--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -13,7 +13,9 @@ namespace :sidekiq do
     task command do
       on roles fetch(:sidekiq_roles) do |role|
         git_plugin.switch_user(role) do
-          git_plugin.systemctl_command(command)
+          git_plugin.process_block do |process|
+            git_plugin.systemctl_command(command, process: process)
+          end
         end
       end
     end

--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -70,7 +70,9 @@ namespace :sidekiq do
   task :quiet do
     on roles fetch(:sidekiq_roles) do |role|
       git_plugin.switch_user(role) do
-        git_plugin.quiet_sidekiq
+        git_plugin.process_block do |process|
+          git_plugin.quiet_sidekiq(process: process)
+        end
       end
     end
   end
@@ -219,8 +221,8 @@ namespace :sidekiq do
     backend.execute(*execute_array, raise_on_non_zero_exit: false)
   end
 
-  def quiet_sidekiq
-    systemctl_command(:kill, '-s', :TSTP)
+  def quiet_sidekiq(process: nil)
+    systemctl_command(:kill, '-s', :TSTP, process: process)
   end
 
   def switch_user(role, &block)


### PR DESCRIPTION
PR #300 seems to have inadvertently broken multi-process support.

Before PR #300, the method `sidekiq_service_unit_name` would generate commands for each numbered sidekiq unit file as long as the config value `sidekiq_processes` was set to a value greater than 1. PR #300 modified that method to only deal with a single process number at a time, which must be explicitly passed in via the `process` argument. However, the tasks that call stop, start, status, and quiet were not updated to pass the process number argument, which meant that those commands would use the unit file name `sidekiq` as if there were only a single process, instead of the correctly named `sidekiq@1`, `sidekiq@2`, etc. unit file names.

This PR updates these tasks to pass in the process numbers using the `process_block` method and makes multi-process work with them again. I also tested this code with `sidekiq_processes` set to 1 and not set, and I can confirm that it still correctly uses the unit file name `sidekiq` in those situations.