### PR TITLE
Revert many changes that break systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ And then execute:
 
     $ bundle
 
-
 ## Usage
 ```ruby
     # Capfile
@@ -24,7 +23,6 @@ And then execute:
     # or
     install_plugin Capistrano::Sidekiq::Monit  # tests needed
 ```
-
 
 Configurable options - Please ensure you check your version's branch for the available settings - shown here with defaults:
 
@@ -73,7 +71,6 @@ in your deploy.rb file:
 SSHKit.config.command_map[:sidekiq] = "bundle exec sidekiq"
 SSHKit.config.command_map[:sidekiqctl] = "bundle exec sidekiqctl"
 ```
-
 
 ## Customizing the monit sidekiq templates
 

--- a/lib/capistrano/sidekiq/helpers.rb
+++ b/lib/capistrano/sidekiq/helpers.rb
@@ -49,5 +49,6 @@ module Capistrano
     def expanded_bundle_path
       backend.capture(:echo, SSHKit.config.command_map[:bundle]).strip
     end
+
   end
 end

--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -277,7 +277,11 @@ namespace :sidekiq do
   # process = 1 | sidekiq_systemd_1.yaml
   # process = nil | sidekiq_systemd_%i.yaml
   def sidekiq_systemd_config_name(process = nil)
-   "sidekiq_systemd_#{(process&.to_s || '%i')}.yaml"
+    if sidekiq_processes > 1
+      "sidekiq_systemd_#{(process&.to_s || '%i')}.yaml"
+    else
+      'sidekiq_systemd.yaml'
+    end
   end
 
   def config_per_process?


### PR DESCRIPTION
I'm the original author of the sidekiq multi process code. I think I have some useful insights into what's happened since my PR was merged.

In #296, an issue was opened about not supporting older versions of systemd that did not support multiple process service naming with the `@` symbol. The solution for this was to make it so that when `sidekiq_processes` is set to 1, it uses the `sidekiq_service_unit_name` without the `@`.

However, the changes implemented in #297 changed the `sidekiq_service_file_name` method to never have the `@` sign, and they changed the `sidekiq_service_unit_name` method to have some conditional logic that doesn't always work.

As a result of the changes in #297, #298 was created, which led to #299. #299 modified the `sidekiq:install` task's functionality in an incorrect way, changing it to create multiple sidekiq@[number].service files, which is not how systemd multiple process support is supposed to work. The purpose of the `@` sign in systemd service file names is that everything after the `@` is passed in as an argument. Therefore, the correct service file name for a multiple process service is sidekiq@.service". This allows for the full functionality of systemd service arguments. For example, ranges are supported, so you can run a command like `systemctl restart sidekiq@{1..3}` and that single command will execute for all 3 processes. Even though creating multiple files does technically work, I don't believe it is correct, and there is no benefit to having multiple identical service files when you only need one.

In order to address the issues created by the changes mentioned above, #300 was created. However, it did not fix everything, which led to #302 and #304, which are further attempts to fix issues created by these changes. Ultimately, you end up with a whole series of changes attempting to patch issues going back to #296. In my opinion, things would be simpler and easier if the code went back to behaving closer to how things were around #296.

The code in this pull request does that. When `sidekiq_processes` is set to one, the systemd unit file will be named "sidekiq.service" and all commands will run on the service named "sidekiq". When `sidekiq_processes` is greater than one, the systemd unit file will be named "sidekiq@.service" and all commands will run either a systemd multi-process command, like `sidekiq@{1..3}`, or, in the case of the restart command, it will run on each numbered process in turn (first `sidekiq@1`, then `sidekiq@2`, etc.).

Finally, in regards to issues around backward compatibility, you can simply run `sidekiq:uninstall` before upgrading and `sidekiq:install` after upgrading. This makes more sense than over complicating the code. 