### PR TITLE
Inject sidekiq:stop after deploy:reverted

### DIFF
--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -8,6 +8,7 @@ namespace :sidekiq do
   task :add_default_hooks do
     after 'deploy:starting', 'sidekiq:quiet' if Rake::Task.task_defined?('sidekiq:quiet')
     after 'deploy:updated', 'sidekiq:stop'
+    after 'deploy:reverted', 'sidekiq:stop'
     after 'deploy:published', 'sidekiq:start'
     after 'deploy:failed', 'sidekiq:restart'
   end


### PR DESCRIPTION
The gem adds hooks for stopping sidekiq after the `deploy:updated` step. This is sufficient for a regular capistrano deploy. However, during a capistrano `deploy:rollback`, the flow is different and `deploy:updated` is not called. Instead, `deploy:reverted` is called. [Here's a link to the Capistrano documentation explaining the flows.](https://capistranorb.com/documentation/getting-started/flow/)

In order to make rollbacks work properly, we need to also add a hook to run `sidekiq:stop` on `deploy:reverted`. This PR adds that hook.