### PR TITLE
Fix: Multiple Sidekiq Processes issue

### DIFF
--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -26,7 +26,9 @@ namespace :sidekiq do
   task :restart do
     on roles fetch(:sidekiq_roles) do |role|
       git_plugin.switch_user(role) do
-        git_plugin.quiet_sidekiq
+        git_plugin.process_block do |process|
+          git_plugin.quiet_sidekiq(process: process)
+        end
         git_plugin.process_block do |process|
           start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           running = nil
@@ -71,7 +73,9 @@ namespace :sidekiq do
   task :quiet do
     on roles fetch(:sidekiq_roles) do |role|
       git_plugin.switch_user(role) do
-        git_plugin.quiet_sidekiq
+        git_plugin.process_block do |process|
+          git_plugin.quiet_sidekiq(process: process)
+        end
       end
     end
   end
@@ -222,8 +226,8 @@ namespace :sidekiq do
     backend.execute(*execute_array, raise_on_non_zero_exit: false)
   end
 
-  def quiet_sidekiq
-    systemctl_command(:kill, '-s', :TSTP)
+  def quiet_sidekiq(process: nil)
+    systemctl_command(:kill, '-s', :TSTP, process: process)
   end
 
   def switch_user(role, &block)

--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -14,7 +14,9 @@ namespace :sidekiq do
     task command do
       on roles fetch(:sidekiq_roles) do |role|
         git_plugin.switch_user(role) do
-          git_plugin.systemctl_command(command)
+          git_plugin.process_block do |process|
+            git_plugin.systemctl_command(command, process: process)
+          end
         end
       end
     end
@@ -84,7 +86,9 @@ namespace :sidekiq do
             git_plugin.create_systemd_config_symlink(process)
           end
         end
-        git_plugin.systemctl_command(:enable)
+        git_plugin.process_block do |process|
+          git_plugin.systemctl_command(:enable, process: process)
+        end
 
         if fetch(:sidekiq_service_unit_user) != :system && fetch(:sidekiq_enable_lingering)
           execute :loginctl, 'enable-linger', fetch(:sidekiq_lingering_user)


### PR DESCRIPTION
When setting `set :sidekiq_processes, 2` or higher, capistrano-sidekiq fails to:

    Create/Start all specified Sidekiq processes properly.
    Stop/terminate them correctly during deployment.

This issue affects deployments where multiple Sidekiq processes are required for parallel processing.
TODO: Ensure the uninstall command properly removes all created processes.

Can this go to v2.3.2?