### PR TITLE
Fix undefined method 'as' error by using backend.as

### DIFF
--- a/lib/capistrano/sidekiq.rb
+++ b/lib/capistrano/sidekiq.rb
@@ -33,7 +33,7 @@ module Capistrano
       if su_user == role.user
         yield
       else
-        as su_user, &block
+        backend.as su_user, &block
       end
     end
 


### PR DESCRIPTION
Fixes #327

The 'as' method needs to be called on the backend object, not directly. This change properly invokes the SSHKit backend method for switching user context during remote command execution.